### PR TITLE
Use time.Sub(time.Now()) rather than time.Until so gokrb5 compiles wi…

### DIFF
--- a/messages/KDCRep.go
+++ b/messages/KDCRep.go
@@ -202,7 +202,7 @@ func (k *ASRep) IsValid(cfg *config.Config, asReq ASReq) (bool, error) {
 	if len(asReq.ReqBody.Addresses) > 0 {
 		//TODO compare if address list is the same
 	}
-	if time.Since(k.DecryptedEncPart.AuthTime) > cfg.LibDefaults.Clockskew || time.Until(k.DecryptedEncPart.AuthTime) > cfg.LibDefaults.Clockskew {
+	if time.Since(k.DecryptedEncPart.AuthTime) > cfg.LibDefaults.Clockskew || k.DecryptedEncPart.AuthTime.Sub(time.Now()) > cfg.LibDefaults.Clockskew {
 		return false, fmt.Errorf("Clock skew with KDC too large. Greater than %v seconds", cfg.LibDefaults.Clockskew.Seconds())
 	}
 	if asReq.PAData.Contains(patype.PA_REQ_ENC_PA_REP) {
@@ -286,7 +286,7 @@ func (k *TGSRep) IsValid(cfg *config.Config, tgsReq TGSReq) (bool, error) {
 	if len(tgsReq.ReqBody.Addresses) > 0 {
 		//TODO compare if address list is the same
 	}
-	if !tgsReq.Renewal && (time.Since(k.DecryptedEncPart.AuthTime) > cfg.LibDefaults.Clockskew || time.Until(k.DecryptedEncPart.AuthTime) > cfg.LibDefaults.Clockskew) {
+	if !tgsReq.Renewal && (time.Since(k.DecryptedEncPart.AuthTime) > cfg.LibDefaults.Clockskew || k.DecryptedEncPart.AuthTime.Sub(time.Now()) > cfg.LibDefaults.Clockskew) {
 		return false, fmt.Errorf("Clock skew with KDC too large. Greater than %v seconds", cfg.LibDefaults.Clockskew.Seconds())
 	}
 	return true, nil


### PR DESCRIPTION
…th go 1.7.3