### PR TITLE
fix bug

### DIFF
--- a/credentials/credentials.go
+++ b/credentials/credentials.go
@@ -7,6 +7,7 @@ import (
 	"gopkg.in/jcmturner/gokrb5.v2/keytab"
 	"gopkg.in/jcmturner/gokrb5.v2/types"
 	"time"
+	"strings"
 )
 
 const (
@@ -59,7 +60,7 @@ func NewCredentials(username string, realm string) Credentials {
 		Realm:       realm,
 		CName: types.PrincipalName{
 			NameType:   nametype.KRB_NT_PRINCIPAL,
-			NameString: []string{username},
+			NameString: strings.Split(username, "/"),
 		},
 		Keytab:     keytab.NewKeytab(),
 		Attributes: make(map[int]interface{}),


### PR DESCRIPTION
When username has '/', the following error will occur：
[Root cause: Encoding_Error] Encoding_Error: AS Exchange Error: failed to process the AS_REP: [KRB Error: (6) KDC_ERR_C_PRINCIPAL_UNKNOWN Client not found in Kerberos database - CLIENT_NOT_FOUND]