### PR TITLE
Minor bug fix for keytab parse

### DIFF
--- a/keytab/keytab.go
+++ b/keytab/keytab.go
@@ -137,9 +137,8 @@ func Parse(b []byte) (kt Keytab, err error) {
 			//Zero padded so skip over
 			l = l * -1
 			n = n + int(l)
-		}
-		if l > 0 {
-			//fmt.Printf("Bytes for entry: %v\n", b[p:p+int(l)])
+		} else {
+			//fmt.Printf("Bytes for entry: %v\n", b[n:n+int(l)])
 			eb := b[n : n+int(l)]
 			n = n + int(l)
 			ke := newKeytabEntry()
@@ -166,7 +165,7 @@ func Parse(b []byte) (kt Keytab, err error) {
 			kt.Entries = append(kt.Entries, ke)
 		}
 		// Check if there are still 4 bytes left to read
-		if len(b[n:]) < 4 {
+		if n > len(b) || len(b[n:]) < 4 {
 			break
 		}
 		// Read the size of the next entry


### PR DESCRIPTION
Hi Jonathan. One small issue I ran into parsing a keytab file I have (generated using ktutil). There is only one entry in this kt file and a zero-filled hole of length 94 to end the file. It parses the entry fine but then tries to read from position 412 (byte array has length 318 and entry 1 ends at 224). I found that the if statements, as they're set up, double count the zero-filled hole section, 224 + (94 * 2) = 412. Looking closer you can see that when a negative length comes up the if block abs vals the length and updates our position (n). It then falls to the next if statement (if l > 0) but, since we abs valued the length it will always be true and we fall into this block. So it double counts the length and probably produces some incorrect parsing. I took out the second if statement and put just the else since we already checked for l == 0 in the for condition. The only other possibility at this point is l > 0. Also added a safety check so we don't index past the end of the array.