### PR TITLE
Add 19 missing error checks found by gometalinter

### DIFF
--- a/client/http.go
+++ b/client/http.go
@@ -32,6 +32,9 @@ func (cl *Client) SetSPNEGOHeader(r *http.Request, spn string) error {
 // SetSPNEGOHeader sets the provided ticket as the SPNEGO authorization header on HTTP request object.
 func SetSPNEGOHeader(creds credentials.Credentials, tkt messages.Ticket, sessionKey types.EncryptionKey, r *http.Request) error {
 	SPNEGOToken, err := gssapi.GetSPNEGOKrbNegTokenInit(creds, tkt, sessionKey)
+	if err != nil {
+		return err
+	}
 	nb, err := SPNEGOToken.Marshal()
 	if err != nil {
 		return krberror.Errorf(err, krberror.EncodingError, "Could marshal SPNEGO")

--- a/gssapi/krb5Token.go
+++ b/gssapi/krb5Token.go
@@ -112,6 +112,9 @@ func NewKRB5APREQMechToken(creds credentials.Credentials, tkt messages.Ticket, s
 		sessionKey,
 		auth,
 	)
+	if err != nil {
+		return []byte{}, err
+	}
 	tb, err = APReq.Marshal()
 	if err != nil {
 		return []byte{}, fmt.Errorf("Could not marshal AP_REQ: %v", err)

--- a/messages/KDCReq.go
+++ b/messages/KDCReq.go
@@ -184,11 +184,17 @@ func NewTGSReq(cname types.PrincipalName, kdcRealm string, c *config.Config, tkt
 		return a, krberror.Errorf(err, krberror.EncryptingError, "Error getting etype to encrypt authenticator")
 	}
 	cb, err := etype.GetChecksumHash(sessionKey.KeyValue, b, keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR_CHKSUM)
+	if err != nil {
+		return a, krberror.Errorf(err, krberror.ChksumError, "Error getting etype checksum hash")
+	}
 	auth.Cksum = types.Checksum{
 		CksumType: etype.GetHashID(),
 		Checksum:  cb,
 	}
 	apReq, err := NewAPReq(tkt, sessionKey, auth)
+	if err != nil {
+		return a, err
+	}
 	apb, err := apReq.Marshal()
 	if err != nil {
 		return a, krberror.Errorf(err, krberror.EncodingError, "Error marshaling AP_REQ for pre-authentication data")

--- a/messages/Ticket.go
+++ b/messages/Ticket.go
@@ -76,6 +76,9 @@ func NewTicket(cname types.PrincipalName, crealm string, sname types.PrincipalNa
 		RenewTill: renewTill,
 	}
 	b, err := asn1.Marshal(etp)
+	if err != nil {
+		return Ticket{}, types.EncryptionKey{}, krberror.Errorf(err, krberror.EncodingError, "Error marshalling encpart")
+	}
 	b = asn1tools.AddASNAppTag(b, asnAppTag.EncTicketPart)
 	skey, err := sktab.GetEncryptionKey(sname.NameString, srealm, kvno, eTypeID)
 	if err != nil {

--- a/pac/kerb_validation_info.go
+++ b/pac/kerb_validation_info.go
@@ -91,13 +91,22 @@ func (k *KerbValidationInfo) Unmarshal(b []byte) (err error) {
 	k.PasswordCanChange = mstypes.ReadFileTime(&b, &p, e)
 	k.PasswordMustChange = mstypes.ReadFileTime(&b, &p, e)
 
-	k.EffectiveName, err = mstypes.ReadRPCUnicodeString(&b, &p, e)
-	k.FullName, err = mstypes.ReadRPCUnicodeString(&b, &p, e)
-	k.LogonScript, err = mstypes.ReadRPCUnicodeString(&b, &p, e)
-	k.ProfilePath, err = mstypes.ReadRPCUnicodeString(&b, &p, e)
-	k.HomeDirectory, err = mstypes.ReadRPCUnicodeString(&b, &p, e)
-	k.HomeDirectoryDrive, err = mstypes.ReadRPCUnicodeString(&b, &p, e)
-	if err != nil {
+	if k.EffectiveName, err = mstypes.ReadRPCUnicodeString(&b, &p, e); err != nil {
+		return
+	}
+	if k.FullName, err = mstypes.ReadRPCUnicodeString(&b, &p, e); err != nil {
+		return
+	}
+	if k.LogonScript, err = mstypes.ReadRPCUnicodeString(&b, &p, e); err != nil {
+		return
+	}
+	if k.ProfilePath, err = mstypes.ReadRPCUnicodeString(&b, &p, e); err != nil {
+		return
+	}
+	if k.HomeDirectory, err = mstypes.ReadRPCUnicodeString(&b, &p, e); err != nil {
+		return
+	}
+	if k.HomeDirectoryDrive, err = mstypes.ReadRPCUnicodeString(&b, &p, e); err != nil {
 		return
 	}
 
@@ -111,9 +120,10 @@ func (k *KerbValidationInfo) Unmarshal(b []byte) (err error) {
 	k.UserFlags = ndr.ReadUint32(&b, &p, e)
 	k.UserSessionKey = mstypes.ReadUserSessionKey(&b, &p, e)
 
-	k.LogonServer, err = mstypes.ReadRPCUnicodeString(&b, &p, e)
-	k.LogonDomainName, err = mstypes.ReadRPCUnicodeString(&b, &p, e)
-	if err != nil {
+	if k.LogonServer, err = mstypes.ReadRPCUnicodeString(&b, &p, e); err != nil {
+		return
+	}
+	if k.LogonDomainName, err = mstypes.ReadRPCUnicodeString(&b, &p, e); err != nil {
 		return
 	}
 
@@ -139,12 +149,24 @@ func (k *KerbValidationInfo) Unmarshal(b []byte) (err error) {
 	k.pResourceGroupIDs = ndr.ReadUint32(&b, &p, e)
 
 	// Populate pointers
-	err = k.EffectiveName.UnmarshalString(&b, &p, e)
-	err = k.FullName.UnmarshalString(&b, &p, e)
-	err = k.LogonScript.UnmarshalString(&b, &p, e)
-	err = k.ProfilePath.UnmarshalString(&b, &p, e)
-	err = k.HomeDirectory.UnmarshalString(&b, &p, e)
-	err = k.HomeDirectoryDrive.UnmarshalString(&b, &p, e)
+	if err = k.EffectiveName.UnmarshalString(&b, &p, e); err != nil {
+		return
+	}
+	if err = k.FullName.UnmarshalString(&b, &p, e); err != nil {
+		return
+	}
+	if err = k.LogonScript.UnmarshalString(&b, &p, e); err != nil {
+		return
+	}
+	if err = k.ProfilePath.UnmarshalString(&b, &p, e); err != nil {
+		return
+	}
+	if err = k.HomeDirectory.UnmarshalString(&b, &p, e); err != nil {
+		return
+	}
+	if err = k.HomeDirectoryDrive.UnmarshalString(&b, &p, e); err != nil {
+		return
+	}
 
 	if k.GroupCount > 0 {
 		ac := ndr.ReadUniDimensionalConformantArrayHeader(&b, &p, e)
@@ -158,8 +180,12 @@ func (k *KerbValidationInfo) Unmarshal(b []byte) (err error) {
 		k.GroupIDs = g
 	}
 
-	err = k.LogonServer.UnmarshalString(&b, &p, e)
-	err = k.LogonDomainName.UnmarshalString(&b, &p, e)
+	if err = k.LogonServer.UnmarshalString(&b, &p, e); err != nil {
+		return
+	}
+	if err = k.LogonDomainName.UnmarshalString(&b, &p, e); err != nil {
+		return
+	}
 
 	if k.pLogonDomainID != 0 {
 		k.LogonDomainID, err = mstypes.ReadRPCSID(&b, &p, e)


### PR DESCRIPTION
```
client/http.go:34:15:warning: ineffectual assignment to err (ineffassign)
gssapi/krb5Token.go:110:9:warning: ineffectual assignment to err (ineffassign)
messages/KDCReq.go:186:6:warning: ineffectual assignment to err (ineffassign)
messages/KDCReq.go:191:9:warning: ineffectual assignment to err (ineffassign)
messages/Ticket.go:78:5:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:94:19:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:95:14:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:96:17:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:97:17:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:98:19:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:114:17:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:142:2:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:143:2:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:144:2:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:145:2:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:146:2:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:147:2:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:161:2:warning: ineffectual assignment to err (ineffassign)
pac/kerb_validation_info.go:162:2:warning: ineffectual assignment to err (ineffassign)
```