### PR TITLE
 Support for cross-realm auth with direct trust

### DIFF
--- a/client/client.go
+++ b/client/client.go
@@ -117,11 +117,6 @@ func NewClientFromCCache(c credentials.CCache) (Client, error) {
 // WithConfig sets the Kerberos configuration for the client.
 func (cl *Client) WithConfig(cfg *config.Config) *Client {
 	cl.Config = cfg
-
-	// Use the default Realm if user did not specified it when creating a client
-	if cl.Credentials.Realm == "" {
-		cl.Credentials.Realm = cl.Config.LibDefaults.DefaultRealm
-	}
 	return cl
 }
 
@@ -199,5 +194,8 @@ func (cl *Client) IsConfigured() (bool, error) {
 
 // Login the client with the KDC via an AS exchange.
 func (cl *Client) Login() error {
+	if cl.Credentials.Realm == "" {
+		cl.Credentials.Realm = cl.Config.LibDefaults.DefaultRealm
+	}
 	return cl.ASExchange(cl.Credentials.Realm, 0)
 }

--- a/client/client.go
+++ b/client/client.go
@@ -4,6 +4,7 @@ package client
 import (
 	"errors"
 	"fmt"
+
 	"gopkg.in/jcmturner/gokrb5.v2/config"
 	"gopkg.in/jcmturner/gokrb5.v2/credentials"
 	"gopkg.in/jcmturner/gokrb5.v2/crypto"
@@ -33,6 +34,7 @@ type Config struct {
 }
 
 // NewClientWithPassword creates a new client from a password credential.
+// Set the realm to empty string to use the default realm from config.
 func NewClientWithPassword(username, realm, password string) Client {
 	creds := credentials.NewCredentials(username, realm)
 	return Client{
@@ -115,6 +117,11 @@ func NewClientFromCCache(c credentials.CCache) (Client, error) {
 // WithConfig sets the Kerberos configuration for the client.
 func (cl *Client) WithConfig(cfg *config.Config) *Client {
 	cl.Config = cfg
+
+	// Use the default Realm if user did not specified it when creating a client
+	if cl.Credentials.Realm == "" {
+		cl.Credentials.Realm = cl.Config.LibDefaults.DefaultRealm
+	}
 	return cl
 }
 
@@ -192,5 +199,5 @@ func (cl *Client) IsConfigured() (bool, error) {
 
 // Login the client with the KDC via an AS exchange.
 func (cl *Client) Login() error {
-	return cl.ASExchange(cl.Config.LibDefaults.DefaultRealm, 0)
+	return cl.ASExchange(cl.Credentials.Realm, 0)
 }

--- a/client/client_integration_test.go
+++ b/client/client_integration_test.go
@@ -5,15 +5,16 @@ package client
 
 import (
 	"encoding/hex"
+	"net/http"
+	"os"
+	"testing"
+
 	"github.com/stretchr/testify/assert"
 	"gopkg.in/jcmturner/gokrb5.v2/config"
 	"gopkg.in/jcmturner/gokrb5.v2/credentials"
 	"gopkg.in/jcmturner/gokrb5.v2/iana/etypeID"
 	"gopkg.in/jcmturner/gokrb5.v2/keytab"
 	"gopkg.in/jcmturner/gokrb5.v2/testdata"
-	"net/http"
-	"os"
-	"testing"
 )
 
 func TestClient_SuccessfulLogin_Keytab(t *testing.T) {
@@ -54,7 +55,7 @@ func TestClient_SuccessfulLogin_Password(t *testing.T) {
 	}
 	for _, test := range tests {
 		c.Realms[0].KDC = []string{addr + ":" + test}
-		cl := NewClientWithPassword("testuser1", "TESTGOKRB5", "passwordvalue")
+		cl := NewClientWithPassword("testuser1", "TEST.GOKRB5", "passwordvalue")
 		cl.WithConfig(c)
 
 		err := cl.Login()
@@ -141,7 +142,7 @@ func TestClient_ASExchange_TGSExchange_EncTypes_Password(t *testing.T) {
 		c.LibDefaults.DefaultTktEnctypeIDs = []int{etypeID.ETypesByName[test]}
 		c.LibDefaults.DefaultTGSEnctypes = []string{test}
 		c.LibDefaults.DefaultTGSEnctypeIDs = []int{etypeID.ETypesByName[test]}
-		cl := NewClientWithPassword("testuser1", "TESTGOKRB5", "passwordvalue")
+		cl := NewClientWithPassword("testuser1", "TEST.GOKRB5", "passwordvalue")
 		cl.WithConfig(c)
 
 		err := cl.Login()

--- a/config/krb5conf.go
+++ b/config/krb5conf.go
@@ -6,8 +6,6 @@ import (
 	"encoding/hex"
 	"errors"
 	"fmt"
-	"github.com/jcmturner/asn1"
-	"gopkg.in/jcmturner/gokrb5.v2/iana/etypeID"
 	"io"
 	"os"
 	"os/user"
@@ -15,6 +13,9 @@ import (
 	"strconv"
 	"strings"
 	"time"
+
+	"github.com/jcmturner/asn1"
+	"gopkg.in/jcmturner/gokrb5.v2/iana/etypeID"
 )
 
 // Config represents the KRB5 configuration.
@@ -431,10 +432,17 @@ func (d *DomainRealm) deleteMapping(domain, realm string) {
 // The most specific mapping is returned.
 func (c *Config) ResolveRealm(domainName string) string {
 	domainName = strings.TrimSuffix(domainName, ".")
+
+	// Try to match the entire hostname first
+	if r, ok := c.DomainRealm[domainName]; ok {
+		return r
+	}
+
+	// Try to match all DNS domain parts
 	periods := strings.Count(domainName, ".") + 1
-	for i := 1; i <= periods; i++ {
+	for i := 2; i <= periods; i++ {
 		z := strings.SplitN(domainName, ".", i)
-		if r, ok := c.DomainRealm[z[len(z)-1]]; ok {
+		if r, ok := c.DomainRealm["."+z[len(z)-1]]; ok {
 			return r
 		}
 	}

--- a/config/krb5conf_test.go
+++ b/config/krb5conf_test.go
@@ -1,11 +1,12 @@
 package config
 
 import (
-	"github.com/stretchr/testify/assert"
 	"io/ioutil"
 	"os"
 	"testing"
 	"time"
+
+	"github.com/stretchr/testify/assert"
 )
 
 const (
@@ -56,6 +57,10 @@ const (
  .test.gokrb5 = TEST.GOKRB5
 
  test.gokrb5 = TEST.GOKRB5
+ 
+  .example.com = EXAMPLE.COM
+ hostname1.example.com = EXAMPLE.COM
+ hostname2.example.com = TEST.GOKRB5
 
 [appdefaults]
  pam = {
@@ -280,4 +285,28 @@ func TestParseDuration(t *testing.T) {
 
 	}
 
+}
+
+func TestResolveRealm(t *testing.T) {
+	c, err := NewConfigFromString(krb5Conf)
+	if err != nil {
+		t.Fatalf("Error loading config: %v", err)
+	}
+
+	tests := []struct {
+		domainName string
+		want       string
+	}{
+		{"unknown.com", "TEST.GOKRB5"},
+		{"hostname1.example.com", "EXAMPLE.COM"},
+		{"hostname2.example.com", "TEST.GOKRB5"},
+		{"one.two.three.example.com", "EXAMPLE.COM"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.domainName, func(t *testing.T) {
+			if got := c.ResolveRealm(tt.domainName); got != tt.want {
+				t.Errorf("Config.ResolveRealm() = %v, want %v", got, tt.want)
+			}
+		})
+	}
 }

--- a/messages/KDCReq.go
+++ b/messages/KDCReq.go
@@ -6,6 +6,10 @@ package messages
 import (
 	"crypto/rand"
 	"fmt"
+	"math"
+	"math/big"
+	"time"
+
 	"github.com/jcmturner/asn1"
 	"gopkg.in/jcmturner/gokrb5.v2/asn1tools"
 	"gopkg.in/jcmturner/gokrb5.v2/config"
@@ -19,9 +23,6 @@ import (
 	"gopkg.in/jcmturner/gokrb5.v2/iana/patype"
 	"gopkg.in/jcmturner/gokrb5.v2/krberror"
 	"gopkg.in/jcmturner/gokrb5.v2/types"
-	"math"
-	"math/big"
-	"time"
 )
 
 type marshalKDCReq struct {
@@ -169,7 +170,7 @@ func NewTGSReq(cname types.PrincipalName, kdcRealm string, c *config.Config, tkt
 		types.SetFlag(&a.ReqBody.KDCOptions, flags.Renew)
 		types.SetFlag(&a.ReqBody.KDCOptions, flags.Renewable)
 	}
-	auth, err := types.NewAuthenticator(c.LibDefaults.DefaultRealm, cname)
+	auth, err := types.NewAuthenticator(tkt.Realm, cname)
 	if err != nil {
 		return a, krberror.Errorf(err, krberror.KRBMsgError, "error generating new authenticator")
 	}


### PR DESCRIPTION
I'm not sure if I get all things correctly, but it works for me and resolves my issue #51.

So the main problem I'm addressing here:
Requesting a ticket for a service in different Realm, other than logged user, raises KDC_ERR_C_PRINCIPAL_UNKNOWN  error if default Realm (from config) is not matching user's Realm.

By comparing the behavior of gokrb5 and MIT's Kerberos in Wireshark, I've realized that there should be an extra step of obtaining TGT from a remote Realm. So I added an additional call `getSessionFromRemoteRealm()` to existing `GetSessionFromRealm()` method that does the job.

Note, my KDC environment is based on AD with multiple domains in a trusted forest.

Additionally I've added few minor related changes:
* fix a bug in `ResolveRealm()` that never matches domain entries from configuration
* use the default Realm from configuration only when Client's credentials missing the Realm

I'm not sure if my changes compliant with RFCs, thus @jcmturner please feel free to amend any part of pull request.  Maybe it would be also a good idea to have a docker image with 2 KDCs trusting each other for integration tests.