### PR TITLE
removed subkey from authenticator within krb5Token

### DIFF
--- a/gssapi/gssapi_test.go
+++ b/gssapi/gssapi_test.go
@@ -47,7 +47,7 @@ func TestUnmarshal_SPNEGO_RespTarg(t *testing.T) {
 	}
 	assert.True(t, s.Resp, "SPNEGO does not indicate it contains NegTokenResp/Targ as expected")
 	assert.False(t, s.Init, "SPNEGO indicates is contains a NegTokenInit but it shouldn't")
-	assert.Equal(t, asn1.Enumerated(0), s.NegTokenResp.NegState, "Negtiation state not as expected.")
+	assert.Equal(t, asn1.Enumerated(0), s.NegTokenResp.NegState, "Negotiation state not as expected.")
 	assert.Equal(t, MechTypeOIDKRB5, s.NegTokenResp.SupportedMech, "SupportedMech type not as expected.")
 }
 

--- a/gssapi/krb5Token.go
+++ b/gssapi/krb5Token.go
@@ -8,7 +8,6 @@ import (
 	"github.com/jcmturner/gofork/encoding/asn1"
 	"gopkg.in/jcmturner/gokrb5.v3/asn1tools"
 	"gopkg.in/jcmturner/gokrb5.v3/credentials"
-	"gopkg.in/jcmturner/gokrb5.v3/crypto"
 	"gopkg.in/jcmturner/gokrb5.v3/iana/chksumtype"
 	"gopkg.in/jcmturner/gokrb5.v3/krberror"
 	"gopkg.in/jcmturner/gokrb5.v3/messages"
@@ -155,11 +154,6 @@ func NewAuthenticator(creds credentials.Credentials, keyType int, flags []int) (
 	if err != nil {
 		return auth, krberror.Errorf(err, krberror.KRBMsgError, "error generating new authenticator")
 	}
-	etype, err := crypto.GetEtype(keyType)
-	if err != nil {
-		return auth, krberror.Errorf(err, krberror.KRBMsgError, "error getting etype for authenticator")
-	}
-	auth.GenerateSeqNumberAndSubKey(keyType, etype.GetKeyByteSize())
 	auth.Cksum = types.Checksum{
 		CksumType: chksumtype.GSSAPI,
 		Checksum:  newAuthenticatorChksum(flags),

--- a/gssapi/krb5Token.go
+++ b/gssapi/krb5Token.go
@@ -147,7 +147,9 @@ func NewAPREQMechToken(creds credentials.Credentials, tkt messages.Ticket, sessi
 	return m, nil
 }
 
-// NewAuthenticator creates a new kerberos authenticator for kerberos MechToken
+// NewAuthenticator (DEPRECATED - this method will be updated in future versions to remove
+// the obsolete keyType argument and may be made private to the gssapi package)
+// creates a new kerberos authenticator for kerberos MechToken
 func NewAuthenticator(creds credentials.Credentials, keyType int, flags []int) (types.Authenticator, error) {
 	//RFC 4121 Section 4.1.1
 	auth, err := types.NewAuthenticator(creds.Realm, creds.CName)

--- a/gssapi/krb5Token_test.go
+++ b/gssapi/krb5Token_test.go
@@ -48,7 +48,7 @@ func TestMechToken_newAuthenticatorWithSubkeyGeneration(t *testing.T) {
 	creds := credentials.NewCredentials("hftsai", testdata.TEST_REALM)
 	creds.CName.NameString = testdata.TEST_PRINCIPALNAME_NAMESTRING
 	etypeID := 18
-	keyLen := 32 // etypeID 18 refers to AES255 -> 32 bytes key
+	keyLen := 32 // etypeID 18 refers to AES256 -> 32 bytes key
 	a, err := NewAuthenticator(creds, etypeID, []int{GSS_C_INTEG_FLAG, GSS_C_CONF_FLAG})
 	if err != nil {
 		t.Fatalf("Error creating authenticator: %v", err)

--- a/gssapi/krb5Token_test.go
+++ b/gssapi/krb5Token_test.go
@@ -43,6 +43,33 @@ func TestMechToken_newAuthenticatorChksum(t *testing.T) {
 	assert.Equal(t, b, cb, "SPNEGO Authenticator checksum not as expected")
 }
 
+// Test with explicit subkey generation.
+func TestMechToken_newAuthenticatorWithSubkeyGeneration(t *testing.T) {
+	creds := credentials.NewCredentials("hftsai", testdata.TEST_REALM)
+	creds.CName.NameString = testdata.TEST_PRINCIPALNAME_NAMESTRING
+	etypeID := 18
+	keyLen := 32 // etypeID 18 refers to AES255 -> 32 bytes key
+	a, err := NewAuthenticator(creds, etypeID, []int{GSS_C_INTEG_FLAG, GSS_C_CONF_FLAG})
+	if err != nil {
+		t.Fatalf("Error creating authenticator: %v", err)
+	}
+	a.GenerateSeqNumberAndSubKey(etypeID, keyLen)
+	assert.Equal(t, 32771, a.Cksum.CksumType, "Checksum type in authenticator for SPNEGO mechtoken not as expected.")
+	assert.Equal(t, etypeID, a.SubKey.KeyType, "Subkey not of the expected type.")
+	assert.Equal(t, keyLen, len(a.SubKey.KeyValue), "Subkey value not of the right length")
+	// Test the subkey is initialised to random non-zero values. Not a perfect test but better than nothing.
+	assert.Condition(t, assert.Comparison(func() bool {
+		return a.SubKey.KeyValue[0] != 0 && a.SubKey.KeyValue[1] != 0 && a.SubKey.KeyValue[0] != a.SubKey.KeyValue[1]
+	}))
+	assert.Condition(t, assert.Comparison(func() bool {
+		return a.SeqNumber > 0
+	}), "Sequence number is not greater than zero")
+	assert.Condition(t, assert.Comparison(func() bool {
+		return a.SeqNumber <= math.MaxUint32
+	}))
+}
+
+// Test without subkey generation.
 func TestMechToken_newAuthenticator(t *testing.T) {
 	creds := credentials.NewCredentials("hftsai", testdata.TEST_REALM)
 	creds.CName.NameString = testdata.TEST_PRINCIPALNAME_NAMESTRING
@@ -52,12 +79,9 @@ func TestMechToken_newAuthenticator(t *testing.T) {
 		t.Fatalf("Error creating authenticator: %v", err)
 	}
 	assert.Equal(t, 32771, a.Cksum.CksumType, "Checksum type in authenticator for SPNEGO mechtoken not as expected.")
-	assert.Equal(t, 18, a.SubKey.KeyType, "Subkey not of the expected type.")
-	assert.Equal(t, 32, len(a.SubKey.KeyValue), "Subkey value not of the right length")
-	// Test the subkey is initialised to random non-zero values. Not a perfect test but better than nothing.
-	assert.Condition(t, assert.Comparison(func() bool {
-		return a.SubKey.KeyValue[0] != 0 && a.SubKey.KeyValue[1] != 0 && a.SubKey.KeyValue[0] != a.SubKey.KeyValue[1]
-	}))
+	assert.Equal(t, 0, a.SubKey.KeyType, "Subkey not of the expected type.")
+	assert.Nil(t, a.SubKey.KeyValue, "Subkey should not be set.")
+
 	assert.Condition(t, assert.Comparison(func() bool {
 		return a.SeqNumber > 0
 	}), "Sequence number is not greater than zero")


### PR DESCRIPTION
The sequence number has already been generated in `types.NewAuthenticator`, and a subkey is not strictly required.

For instances where a subkey is required and depending on the use case (ie, when the Authenticator is generated through a call to `NewNegTokenInitKrb5`), it will need to be propagated back to the caller before the authenticator is serialized.

Remarks:
  - Added a test case to check the authenticator for both cases
  - `NewAuthenticator ` now has a useless parameter (`keyType int`). Options: add a new function with another name and deprecate this one?
  - Other option: leave `NewAuthenticator` as is and create another function that does not generate subkeys

On testing:
 - all package tests seem to pass.
 - the current code allows me to do a kerberos authentication handshake with an hadoop namenode. I don't know if everything is as it should be per RFCs, but in my current use case it works.
 - I have no clue if serialising the Authenticator struct without a subkey yields the expected results in other situations (ie, SPNEGO or anything else).

PS: at least another PR is in the pipeline, I prefer to keep things small and simple :) 
