### PR TITLE
fixes "no Go files in" error on go get

### DIFF
--- a/gokrb5.go
+++ b/gokrb5.go
@@ -1,0 +1,2 @@
+// Package gokrb5 provides a Go file to avoid the error "no Go files in" when performing "go get" of gokrb5
+package gokrb5


### PR DESCRIPTION
The "go get gopkg.in/jcmturner/gokrb5.v#" command errors with:
"package gopkg.in/jcmturner/gokrb5.v3: no Go files in 
$GOPATH/src/gopkg.in/jcmturner/gokrb5.v#"
This is not a real issue so simple fix is to add a go file to stop this 
error.