### PR TITLE
marshal keytab to []byte and write to io.Writer

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,7 @@ go:
   - 1.7.x
   - 1.8.x
   - 1.9.x
+  - 1.10.x
   - master
 
 go_import_path: gopkg.in/jcmturner/gokrb5.v4

--- a/client/client_integration_test.go
+++ b/client/client_integration_test.go
@@ -364,17 +364,17 @@ func TestMultiThreadedClientUse(t *testing.T) {
 		go func() {
 			defer wg.Done()
 			login(t, &cl)
-		}
+		}()
 	}
 	wg.Wait()
 
 	var wg2 sync.WaitGroup
 	wg2.Add(5)
 	for i := 0; i < 5; i++ {
-		go func(){
+		go func() {
 			defer wg.Done()
 			spnegoGet(t, &cl)
-		}
+		}()
 	}
 	wg2.Wait()
 }

--- a/keytab/keytab.go
+++ b/keytab/keytab.go
@@ -134,7 +134,7 @@ func (kt Keytab) Write(w io.Writer) (int, error) {
 // Parse byte slice of Keytab data into Keytab type.
 func Parse(b []byte) (kt Keytab, err error) {
 	//The first byte of the file always has the value 5
-	if int8(b[0]) != 5 {
+	if b[0] != keytabFirstByte {
 		err = errors.New("Invalid keytab data. First byte does not equal 5")
 		return
 	}

--- a/keytab/keytab.go
+++ b/keytab/keytab.go
@@ -108,7 +108,8 @@ func Load(ktPath string) (kt Keytab, err error) {
 	return Parse(k)
 }
 
-func (kt Keytab) marshal() ([]byte, error) {
+// Marshal keytab into byte slice
+func (kt Keytab) Marshal() ([]byte, error) {
 	b := []byte{keytabFirstByte, kt.Version}
 	for _, e := range kt.Entries {
 		eb, err := e.marshal(int(kt.Version))
@@ -120,8 +121,10 @@ func (kt Keytab) marshal() ([]byte, error) {
 	return b, nil
 }
 
+// Write the keytab bytes to io.Writer.
+// Returns the number of bytes written
 func (kt Keytab) Write(w io.Writer) (int, error) {
-	b, err := kt.marshal()
+	b, err := kt.Marshal()
 	if err != nil {
 		return 0, fmt.Errorf("error marshaling keytab: %v", err)
 	}
@@ -239,7 +242,7 @@ func (e entry) marshal(v int) ([]byte, error) {
 }
 
 // Parse the Keytab bytes of a principal into a Keytab entry's principal.
-func parsePrincipal(b []byte, p *int, kt *Keytab, ke *entry, e *binary.ByteOrder) (err error) {
+func parsePrincipal(b []byte, p *int, kt *Keytab, ke *entry, e *binary.ByteOrder) error {
 	ke.Principal.NumComponents = readInt16(b, p, e)
 	if kt.Version == 1 {
 		//In version 1 the number of components includes the realm. Minus 1 to make consistent with version 2

--- a/keytab/keytab.go
+++ b/keytab/keytab.go
@@ -258,7 +258,7 @@ func parsePrincipal(b []byte, p *int, kt *Keytab, ke *entry, e *binary.ByteOrder
 		//Name Type is omitted in version 1
 		ke.Principal.NameType = readInt32(b, p, e)
 	}
-	return
+	return nil
 }
 
 func (p principal) marshal(v int) ([]byte, error) {

--- a/keytab/keytab_test.go
+++ b/keytab/keytab_test.go
@@ -3,27 +3,42 @@ package keytab
 import (
 	"encoding/hex"
 	"github.com/stretchr/testify/assert"
+	"gopkg.in/jcmturner/gokrb5.v4/testdata"
 	"testing"
 	"time"
 )
 
-//Keytab data generated from ktutil
-const keytabDataHexStr = "0502000000320001000b4558414d504c452e434f4d00047573657200000001586aa82d01001700100c61039f010b2fbb88fe449fbf262477000000420001000b4558414d504c452e434f4d00047573657200000001586aa82d010012002053142f614ee6c39823710d9f31ff2984ed0bd9074d6e542e8468137f7b909c17000000320001000b4558414d504c452e434f4d00047573657200000001586beaad01001700100c61039f010b2fbb88fe449fbf262477000000420001000b4558414d504c452e434f4d00047573657200000001586beaae010012002053142f614ee6c39823710d9f31ff2984ed0bd9074d6e542e8468137f7b909c17000000430001000b4a544c414e2e434f2e554b000562696c6c7900000001586beaae1f00120020508dd2b209064e101bf209caef5fda236875706a5e9ad47c157db5907778785f"
-
 func TestParse(t *testing.T) {
-	dat, _ := hex.DecodeString(keytabDataHexStr)
+	dat, _ := hex.DecodeString(testdata.TESTUSER1_KEYTAB)
 	kt, err := Parse(dat)
 	if err != nil {
 		t.Fatalf("Error parsing keytab data: %v\n", err)
 	}
-	assert.Equal(t, uint16(2), kt.Version, "Keytab version not as expected")
+	assert.Equal(t, uint8(2), kt.Version, "Keytab version not as expected")
 	assert.Equal(t, uint32(1), kt.Entries[0].KVNO, "KVNO not as expected")
 	assert.Equal(t, uint8(1), kt.Entries[0].KVNO8, "KVNO8 not as expected")
-	assert.Equal(t, time.Unix(1483384877, 0), kt.Entries[0].Timestamp, "Timestamp not as expected")
-	assert.Equal(t, int32(23), kt.Entries[0].Key.KeyType, "Key's EType not as expected")
-	assert.Equal(t, "0c61039f010b2fbb88fe449fbf262477", hex.EncodeToString(kt.Entries[0].Key.KeyValue), "Key material not as expected")
+	assert.Equal(t, time.Unix(1505669592, 0), kt.Entries[0].Timestamp, "Timestamp not as expected")
+	assert.Equal(t, int32(17), kt.Entries[0].Key.KeyType, "Key's EType not as expected")
+	assert.Equal(t, "698c4df8e9f60e7eea5a21bf4526ad25", hex.EncodeToString(kt.Entries[0].Key.KeyValue), "Key material not as expected")
 	assert.Equal(t, int16(1), kt.Entries[0].Principal.NumComponents, "Number of components in principal not as expected")
 	assert.Equal(t, int32(1), kt.Entries[0].Principal.NameType, "Name type of principal not as expected")
-	assert.Equal(t, "EXAMPLE.COM", kt.Entries[0].Principal.Realm, "Realm of principal not as expected")
-	assert.Equal(t, "user", kt.Entries[0].Principal.Components[0], "Component in principal not as expected")
+	assert.Equal(t, "TEST.GOKRB5", kt.Entries[0].Principal.Realm, "Realm of principal not as expected")
+	assert.Equal(t, "testuser1", kt.Entries[0].Principal.Components[0], "Component in principal not as expected")
+}
+
+func TestMarshal(t *testing.T) {
+	dat, _ := hex.DecodeString(testdata.TESTUSER1_KEYTAB)
+	kt, err := Parse(dat)
+	if err != nil {
+		t.Fatalf("Error parsing keytab data: %v\n", err)
+	}
+	b, err := kt.marshal()
+	if err != nil {
+		t.Fatalf("Error marshaling: %v", err)
+	}
+	assert.Equal(t, dat, b, "Marshaled bytes not the same as input bytes")
+	_, err = Parse(b)
+	if err != nil {
+		t.Fatalf("Error parsing marshaled bytes: %v", err)
+	}
 }

--- a/keytab/keytab_test.go
+++ b/keytab/keytab_test.go
@@ -32,7 +32,7 @@ func TestMarshal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing keytab data: %v\n", err)
 	}
-	b, err := kt.marshal()
+	b, err := kt.Marshal()
 	if err != nil {
 		t.Fatalf("Error marshaling: %v", err)
 	}

--- a/types/HostAddress.go
+++ b/types/HostAddress.go
@@ -120,6 +120,7 @@ func LocalHostAddresses() (ha HostAddresses, err error) {
 	return ha, nil
 }
 
+// HostAddressFromNetIPs returns a HostAddresses type from a slice of net.IP
 func HostAddressesFromNetIPs(ips []net.IP) (ha HostAddresses) {
 	for _, ip := range ips {
 		ha = append(ha, HostAddressFromNetIP(ip))
@@ -127,6 +128,7 @@ func HostAddressesFromNetIPs(ips []net.IP) (ha HostAddresses) {
 	return ha
 }
 
+// HostAddressFromNetIP returns a HostAddress type from a net.IP
 func HostAddressFromNetIP(ip net.IP) HostAddress {
 	if ip.To4() != nil {
 		//Is IPv4
@@ -134,11 +136,10 @@ func HostAddressFromNetIP(ip net.IP) HostAddress {
 			AddrType: addrtype.IPv4,
 			Address:  ip.To4(),
 		}
-	} else {
-		return HostAddress{
-			AddrType: addrtype.IPv6,
-			Address:  ip.To16(),
-		}
+	}
+	return HostAddress{
+		AddrType: addrtype.IPv6,
+		Address:  ip.To16(),
 	}
 }
 


### PR DESCRIPTION
Provides the ability to marshal a keytab to []byte and a method to write those bytes to an io.Writer.

Tests have been updated to include Go 1.10
Tests were fixed to resolve an issue where the test func would end before all go routines spawned had finished.
