### PR TITLE
support service principal with slash

### DIFF
--- a/messages/Ticket.go
+++ b/messages/Ticket.go
@@ -3,6 +3,7 @@ package messages
 import (
 	"crypto/rand"
 	"fmt"
+	"strings"
 	"time"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
@@ -188,7 +189,7 @@ func MarshalTicketSequence(tkts []Ticket) (asn1.RawValue, error) {
 func (t *Ticket) DecryptEncPart(keytab keytab.Keytab, sa string) error {
 	var upn []string
 	if sa != "" {
-		upn = []string{sa}
+		upn = strings.Split(sa, "/")
 	} else {
 		upn = t.SName.NameString
 	}


### PR DESCRIPTION
Hi,

we're using gokrb in vault-plugin-auth-kerberos to authenticate users, and noticed that we were getting unexpected "Matching key not found in keytab" errors when service principals contained slashes/multiple components, e.g. "HTTP/full-hostname.keytab@EXAMPLE.COM".

There is more detail in https://github.com/wintoncode/vault-plugin-auth-kerberos/issues/1

It turns out that this is because the the `sa` is represented differently, in the keytab it's a list of components (`["HTTP", "full-hostname.keytab@EXAMPLE.COM"]`), in `ValidateAPREQ` it's a single string `"HTTP/full-hostname.keytab@EXAMPLE.COM"`.
`DecryptEncPart` in https://github.com/jcmturner/gokrb5/blob/master/messages/Ticket.go#L191 currently simply converts the single string into a list containing that single string: `["HTTP/full-hostname.keytab@EXAMPLE.COM"]`.

Therefore when `GetEncryptionKey` is called, the lengths of both lists don't match and it can't find the key in the keytab.

The reason that the version in the keytab is split up is the keytab format and parsing here: https://github.com/jcmturner/gokrb5/blob/master/keytab/keytab.go#L246

The proposed solution is to simply split up the string into it's components.

All the work for this was done by @kristian-lesko in https://github.com/wintoncode/vault-plugin-auth-kerberos/pull/2/files, thanks a lot Kristian!