### PR TITLE
fixes CI gofmt test

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -37,7 +37,7 @@ env:
   - TEST_KDC_ADDR=127.0.0.1 TEST_HTTP_URL="http://host.test.gokrb5/index.html" DNSUTILS_OVERRIDE_NS="127.0.0.1:53"
 
 script:
-  - test -z $(gofmt -s -l $GO_FILES)         # Fail if a .go file hasn't been formatted with gofmt
+  - test -z $(gofmt -s -d -l -e $GO_FILES | tee /dev/fd/2 | xargs | sed 's/\s//g') # Fail if a .go file hasn't been formatted with gofmt
   - go vet ./...                             # go vet is the official Go static analyzer
   #- golint -set_exit_status $(go list ./...) # golint to be added
   - go test -v -race -tags="integration dns" ./... # Run all the tests with the race detector enabled and integration tests

--- a/config/krb5conf.go
+++ b/config/krb5conf.go
@@ -101,12 +101,12 @@ func newLibDefaults() *LibDefaults {
 		KDCTimeSync:             1,
 		NoAddresses:             true,
 		PermittedEnctypes:       []string{"aes256-cts-hmac-sha1-96", "aes128-cts-hmac-sha1-96", "des3-cbc-sha1", "arcfour-hmac-md5", "camellia256-cts-cmac", "camellia128-cts-cmac", "des-cbc-crc", "des-cbc-md5", "des-cbc-md4"},
+		RDNS:                    true,
+		RealmTryDomains:         -1,
+		SafeChecksumType:        8,
+		TicketLifetime:          time.Duration(24) * time.Hour,
+		UDPPreferenceLimit:      1465,
 		PreferredPreauthTypes:   []int{17, 16, 15, 14},
-		RDNS:               true,
-		RealmTryDomains:    -1,
-		SafeChecksumType:   8,
-		TicketLifetime:     time.Duration(24) * time.Hour,
-		UDPPreferenceLimit: 1465,
 	}
 }
 


### PR DESCRIPTION
Fix formatting to work for older and latest gofmt.
Update Travis CI configuration to output details of failed gofmt test.