### PR TITLE
associate KRB_NT_SRV_INST with AP_REQ_AUTHENTICATOR in messages/APReq…

### DIFF
--- a/examples/httpServer.go
+++ b/examples/httpServer.go
@@ -27,7 +27,7 @@ func main() {
 
 	// Set up handler mappings wrapping in the SPNEGOKRB5Authenticate handler wrapper
 	mux := http.NewServeMux()
-	mux.Handle("/", service.SPNEGOKRB5Authenticate(th, kt, "", l))
+	mux.Handle("/", service.SPNEGOKRB5Authenticate(th, kt, "", false, l))
 
 	// Start up the web server
 	log.Fatal(http.ListenAndServe(":9080", mux))
@@ -37,6 +37,6 @@ func main() {
 func testAppHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	ctx := r.Context()
-	fmt.Fprintf(w, "<html>\nTEST.GOKRB5 Handler\nAuthenticed user: %s\nUser's realm: %s\n</html>", ctx.Value(service.CREDENTIALS_CTXKEY).(credentials.Credentials).Username, ctx.Value(service.CREDENTIALS_CTXKEY).(credentials.Credentials).Realm)
+	fmt.Fprintf(w, "<html>\nTEST.GOKRB5 Handler\nAuthenticed user: %s\nUser's realm: %s\n</html>", ctx.Value(service.CTXKeyCredentials).(credentials.Credentials).Username, ctx.Value(service.CTXKeyCredentials).(credentials.Credentials).Realm)
 	return
 }

--- a/messages/APReq.go
+++ b/messages/APReq.go
@@ -72,7 +72,7 @@ func encryptAuthenticator(a types.Authenticator, sessionKey types.EncryptionKey,
 	}
 	var usage int
 	switch tkt.SName.NameType {
-	case nametype.KRB_NT_PRINCIPAL:
+	case nametype.KRB_NT_PRINCIPAL,nametype.KRB_NT_SRV_INST:
 		usage = keyusage.AP_REQ_AUTHENTICATOR
 	case nametype.KRB_NT_SRV_INST:
 		usage = keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR
@@ -89,7 +89,7 @@ func encryptAuthenticator(a types.Authenticator, sessionKey types.EncryptionKey,
 func (a *APReq) DecryptAuthenticator(sessionKey types.EncryptionKey) (auth types.Authenticator, err error) {
 	var usage uint32
 	switch a.Ticket.SName.NameType {
-	case nametype.KRB_NT_PRINCIPAL:
+	case nametype.KRB_NT_PRINCIPAL,nametype.KRB_NT_SRV_INST:
 		usage = keyusage.AP_REQ_AUTHENTICATOR
 	case nametype.KRB_NT_SRV_INST:
 		usage = keyusage.TGS_REQ_PA_TGS_REQ_AP_REQ_AUTHENTICATOR


### PR DESCRIPTION
… and fix examples/httpServer to reflect new paramaters and contstans

This will allow those of us coming from the apache mod_auth_kerb world to re use out keytabs that have the format HTTP/fqdn.

Also update the example for the added function parameter needed for SPNEGOKRB5Authenticate

And BTW - Thanks so much for writing this library.