### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,7 +125,7 @@ This will involve these steps:
 
 * Generate a new Authenticator and generate a sequence number and subkey:
 ```go
-auth := types.NewAuthenticator(cl.Credentials.Realm, cl.Credentials.CName)
+auth, _ := types.NewAuthenticator(cl.Credentials.Realm, cl.Credentials.CName)
 etype, _ := crypto.GetEtype(key.KeyType)
 auth.GenerateSeqNumberAndSubKey(key.KeyType, etype.GetKeyByteSize())
 ```


### PR DESCRIPTION
NewAuthenticator returns (Authenticator, error), so 2 values on the left side of the assignment are needed.