### PR TITLE
print AS or TGS exchange errors from the KDC as "KDC_Error"

### DIFF
--- a/client/ASExchange.go
+++ b/client/ASExchange.go
@@ -40,7 +40,11 @@ func (cl *Client) ASExchange(realm string, ASReq messages.ASReq, referral int) (
 				}
 				rb, err = cl.SendToKDC(b, realm)
 				if err != nil {
-					return messages.ASRep{}, krberror.Errorf(err, krberror.NetworkingError, "AS Exchange Error: failed sending AS_REQ to KDC")
+					if _, ok := err.(messages.KRBError); ok {
+						return messages.ASRep{}, krberror.Errorf(err, krberror.KDCError, "AS Exchange Error: error response from KDC")
+					} else {
+						return messages.ASRep{}, krberror.Errorf(err, krberror.NetworkingError, "AS Exchange Error: failed sending AS_REQ to KDC")
+					}
 				}
 			case errorcode.KDC_ERR_WRONG_REALM:
 				// Client referral https://tools.ietf.org/html/rfc6806.html#section-7

--- a/client/TGSExchange.go
+++ b/client/TGSExchange.go
@@ -28,7 +28,11 @@ func (cl *Client) TGSExchange(spn types.PrincipalName, kdcRealm string, tkt mess
 	}
 	r, err := cl.SendToKDC(b, kdcRealm)
 	if err != nil {
-		return tgsReq, tgsRep, krberror.Errorf(err, krberror.NetworkingError, "TGS Exchange Error: issue sending TGS_REQ to KDC")
+		if _, ok := err.(messages.KRBError); ok {
+			return tgsReq, tgsRep, krberror.Errorf(err, krberror.KDCError, "TGS Exchange Error: error response from KDC")
+		} else {
+			return tgsReq, tgsRep, krberror.Errorf(err, krberror.NetworkingError, "TGS Exchange Error: issue sending TGS_REQ to KDC")
+		}
 	}
 	err = tgsRep.Unmarshal(r)
 	if err != nil {

--- a/krberror/error.go
+++ b/krberror/error.go
@@ -16,6 +16,7 @@ const (
 	ChksumError     = "Checksum_Error"
 	KRBMsgError     = "KRBMessage_Handling_Error"
 	ConfigError     = "Configuration_Error"
+	KDCError        = "KDC_Error"
 )
 
 // Krberror is an error type for gokrb5


### PR DESCRIPTION
Fixes https://github.com/jcmturner/gokrb5/issues/161

We make an assumption that errors from `SendToKDC()` of type `KRBError` come from the KDC.
