### PR TITLE
fix httpServer.go example

### DIFF
--- a/examples/httpServer.go
+++ b/examples/httpServer.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 
-	// "gopkg.in/jcmturner/gokrb5.v6/credentials"
 	goidentity "gopkg.in/jcmturner/goidentity.v3"
 	"gopkg.in/jcmturner/gokrb5.v6/keytab"
 	"gopkg.in/jcmturner/gokrb5.v6/service"

--- a/examples/httpServer.go
+++ b/examples/httpServer.go
@@ -45,7 +45,7 @@ func main() {
 func testAppHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	ctx := r.Context()
-	creds := ctx.Value(service.CTXKeyCredentials).(credentials.Credentials)
+	creds := ctx.Value(service.CTXKeyCredentials).(*credentials.Credentials)
 	fmt.Fprintf(w,
 		`<html>
 <h1>GOKRB5 Handler</h1>

--- a/examples/httpServer.go
+++ b/examples/httpServer.go
@@ -10,7 +10,8 @@ import (
 	"os"
 
 	//"github.com/pkg/profile"
-	"gopkg.in/jcmturner/gokrb5.v6/credentials"
+	// "gopkg.in/jcmturner/gokrb5.v6/credentials"
+	goidentity "gopkg.in/jcmturner/goidentity.v3"
 	"gopkg.in/jcmturner/gokrb5.v6/keytab"
 	"gopkg.in/jcmturner/gokrb5.v6/service"
 	"gopkg.in/jcmturner/gokrb5.v6/testdata"

--- a/examples/httpServer.go
+++ b/examples/httpServer.go
@@ -9,7 +9,6 @@ import (
 	"net/http"
 	"os"
 
-	//"github.com/pkg/profile"
 	// "gopkg.in/jcmturner/gokrb5.v6/credentials"
 	goidentity "gopkg.in/jcmturner/goidentity.v3"
 	"gopkg.in/jcmturner/gokrb5.v6/keytab"

--- a/examples/httpServer.go
+++ b/examples/httpServer.go
@@ -45,7 +45,7 @@ func main() {
 func testAppHandler(w http.ResponseWriter, r *http.Request) {
 	w.WriteHeader(http.StatusOK)
 	ctx := r.Context()
-	creds := ctx.Value(service.CTXKeyCredentials).(*credentials.Credentials)
+	creds := ctx.Value(service.CTXKeyCredentials).(goidentity.Identity)
 	fmt.Fprintf(w,
 		`<html>
 <h1>GOKRB5 Handler</h1>


### PR DESCRIPTION
Tried this with a real keytab, but got this at runtime:
GOKRB5 Service: 2018/09/11 11:27:23 http.go:57: 192.168.139.137:43856 user@REALM - SPNEGO authentication succeeded
2018/09/11 11:27:23 http: panic serving 1.2.3.4:2345: interface conversion: interface {} is *credentials.Credentials, not credentials.Credentials

Works if I change to ... .(*credentials.Credentials)