### PR TITLE
fix some codespell issues

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -49,7 +49,7 @@ This would require a minor (v\_.X.\_) version update.
 As gokrb5 is designed to be a core library used in other applications it is best to avoid dependencies the project has 
 no control over, other than the Go standard library, as issues with any dependency could have large knock on effects.
 * Provide useful commit messages.
-* Pull requests must address one issue only and keep to the scope of the issue. This makes it easier to review and merge, so your contribution will get 
+* Pull requests must address one issue only and keep to the scope of the issue. This makes it easier to review and merge, so your contribution will get
 incorporated faster this way.
 * Pull requests must have a message obeying this format:
 ```
@@ -57,13 +57,13 @@ incorporated faster this way.
 
 More detailed explanatory text. This should reference the related issue.
 ```
-This to adhere to the [git best practice](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project) and 
-mirror the [contribution guidelines for the Go standard libarary](https://golang.org/doc/contribute.html).
+This to adhere to the [git best practice](https://git-scm.com/book/en/v2/Distributed-Git-Contributing-to-a-Project) and
+mirror the [contribution guidelines for the Go standard library](https://golang.org/doc/contribute.html).
 An Example:
 ```
 update to the godoc comments for the function Blah
 
-The godoc comments to function subpkg.Blah have been updated to make it 
+The godoc comments to function subpkg.Blah have been updated to make it
 clearer as to what the function is for.
 ```
 
@@ -74,7 +74,7 @@ A good rule of thumb: The easier you make it for the reader of an issue to help 
 When raising bugs please include the following items in your issue:
 * The version of gokrb5 being used (vX.Y.Z or master or branch name).
 * The version of Go being used (output of the ```go version``` command is handy).
-* Details of the environment in which you are seeing the issue. For example, what is being used as the KDC, 
+* Details of the environment in which you are seeing the issue. For example, what is being used as the KDC,
 what the krb5.conf contains, etc.
 * Details on how to re-create the issue.
 * Details on what you are experiencing that indicates the issue.
@@ -84,7 +84,7 @@ what the krb5.conf contains, etc.
 
 #### Enhancements 
 When raising enhancement requests or suggestions please include the following:
-* What the enhancment is or would do.
+* What the enhancement is or would do.
 * Why you need the enhancement or why you think it would be a good idea.
 * Any suggestions you may have on how to implement.
 
@@ -95,7 +95,7 @@ Running the tests without any particular switches runs only the unit tests.
 
 It is recommended to run tests with the ```-race``` argument.
 
-There are integration tests that run against various other network services such as KDCs, HTTP web servers, DNS servers, 
+There are integration tests that run against various other network services such as KDCs, HTTP web servers, DNS servers,
 etc. To run these pass ```-tags=integration``` as an argument to the go test command.
-There are vagrant and docker resources available to spin up these network services. See the 
+There are vagrant and docker resources available to spin up these network services. See the
 [readme](https://github.com/jcmturner/gokrb5/blob/master/testenv/README.md) in the testenv directory for instructions.

--- a/client/ASExchange.go
+++ b/client/ASExchange.go
@@ -14,7 +14,7 @@ import (
 // ASExchange performs an AS exchange for the client to retrieve a TGT.
 func (cl *Client) ASExchange(realm string, ASReq messages.ASReq, referral int) (messages.ASRep, error) {
 	if ok, err := cl.IsConfigured(); !ok {
-		return messages.ASRep{}, krberror.Errorf(err, krberror.ConfigError, "AS Exchange cannot be preformed")
+		return messages.ASRep{}, krberror.Errorf(err, krberror.ConfigError, "AS Exchange cannot be performed")
 	}
 
 	b, err := ASReq.Marshal()

--- a/crypto/rfc3961/keyDerivation.go
+++ b/crypto/rfc3961/keyDerivation.go
@@ -30,7 +30,7 @@ func DeriveRandom(key, usage []byte, e etype.EType) ([]byte, error) {
 	out := make([]byte, k/8)
 
 	/*If the output	of E is shorter than k bits, it is fed back into the encryption as many times as necessary.
-	The construct is as follows (where | indicates concatentation):
+	The construct is as follows (where | indicates concatenation):
 
 	K1 = E(Key, n-fold(Constant), initial-cipher-state)
 	K2 = E(Key, K1, initial-cipher-state)

--- a/gssapi/WrapToken.go
+++ b/gssapi/WrapToken.go
@@ -45,7 +45,7 @@ From RFC 4121, section 4.2.6.2:
                              4.2.4.
 
 Quick notes:
-	- "EC" or "Extra Count" refers to the length of the cheksum.
+	- "EC" or "Extra Count" refers to the length of the checksum.
 	- "Flags" (complete details in section 4.2.2) is a set of bits:
 		- if bit 0 is set, it means the token was sent by the acceptor (generally the kerberized service).
 		- bit 1 indicates that the token's payload is encrypted
@@ -220,7 +220,7 @@ func NewInitiatorToken(payload []byte, key types.EncryptionKey) (*WrapToken, err
 
 	token := WrapToken{
 		Flags: 0x00, // all zeroed out (this is a token sent by the initiator)
-		// Checksum size: lenth of output of the HMAC function, in bytes.
+		// Checksum size: length of output of the HMAC function, in bytes.
 		EC:        uint16(encType.GetHMACBitLength() / 8),
 		RRC:       0,
 		SndSeqNum: 0,

--- a/gssapi/WrapToken_test.go
+++ b/gssapi/WrapToken_test.go
@@ -186,6 +186,6 @@ func TestMarshal_Failures(t *testing.T) {
 func TestNewInitiatorTokenSignatureAndMarshalling(t *testing.T) {
 	t.Parallel()
 	token, tErr := NewInitiatorToken([]byte{0x01, 0x01, 0x00, 0x00}, getSessionKey())
-	assert.Nil(t, tErr, "Unexepected error.")
+	assert.Nil(t, tErr, "Unexpected error.")
 	assert.Equal(t, getResponseReference(), token, "Token failed to be marshalled to the expected bytes.")
 }

--- a/messages/KDCRep.go
+++ b/messages/KDCRep.go
@@ -166,7 +166,7 @@ func (k *ASRep) DecryptEncPart(c *credentials.Credentials) (types.EncryptionKey,
 		}
 	}
 	if !c.HasKeytab() && !c.HasPassword() {
-		return key, krberror.NewErrorf(krberror.DecryptingError, "no secret available in credentials to preform decryption of AS_REP encrypted part")
+		return key, krberror.NewErrorf(krberror.DecryptingError, "no secret available in credentials to perform decryption of AS_REP encrypted part")
 	}
 	b, err := crypto.DecryptEncPart(k.EncPart, key, keyusage.AS_REP_ENCPART)
 	if err != nil {

--- a/messages/Ticket.go
+++ b/messages/Ticket.go
@@ -139,7 +139,7 @@ func UnmarshalTicketsSequence(in asn1.RawValue) ([]Ticket, error) {
 	for p < (len(b)) {
 		_, err := asn1.UnmarshalWithParams(b[p:], &raw, fmt.Sprintf("application,tag:%d", asnAppTag.Ticket))
 		if err != nil {
-			return nil, fmt.Errorf("unmarshaling sequence of tickets failed geting length of ticket: %v", err)
+			return nil, fmt.Errorf("unmarshaling sequence of tickets failed getting length of ticket: %v", err)
 		}
 		t, err := UnmarshalTicket(b[p:])
 		if err != nil {
@@ -166,7 +166,7 @@ func MarshalTicketSequence(tkts []Ticket) (asn1.RawValue, error) {
 	for i, t := range tkts {
 		b, err := t.Marshal()
 		if err != nil {
-			return raw, fmt.Errorf("error marshaling ticket number %d in seqence of tickets", i+1)
+			return raw, fmt.Errorf("error marshaling ticket number %d in sequence of tickets", i+1)
 		}
 		btkts = append(btkts, b...)
 	}


### PR DESCRIPTION
Hi @jcmturner,

I fixed some [codespell](https://github.com/codespell-project/codespell) issues. There are some false positives more, but you could add this tool to the CI. 

See,
```
$ codespell -S ./vendor*,./testenv*,./.git*
```