### PR TITLE
service: Respect RequiredHostAddr when ticket contains client addresses

### DIFF
--- a/service/APExchange.go
+++ b/service/APExchange.go
@@ -28,7 +28,7 @@ func ValidateAPREQ(APReq messages.APReq, sa SPNEGOAuthenticator) (bool, credenti
 		err := messages.NewKRBError(APReq.Ticket.SName, APReq.Ticket.Realm, errorcode.KRB_AP_ERR_BADMATCH, "CName in Authenticator does not match that in service ticket")
 		return false, creds, err
 	}
-	if len(APReq.Ticket.DecryptedEncPart.CAddr) > 0 {
+	if sa.Config.RequireHostAddr && len(APReq.Ticket.DecryptedEncPart.CAddr) > 0 {
 		//The addresses in the ticket (if any) are then
 		//searched for an address matching the operating-system reported
 		//address of the client.  If no match is found or the server insists on


### PR DESCRIPTION
When the KDC is configured with noaddresses=false, the ticket will contain
client addresses it was issued for.

We still want to be able to disable the check on the service side though. It's
not unsual that the client address can't really be checked against, .eg SNAT
will effectly hide the client address we want to verify.

This commit changes the current behaviour: if the ticket contains client
addresses but RequireHostAddr is false (which is the default value),
ValidateAPREQ will now pass (it used to error out). The library user has to
explictly set RequireHostAddr to true for that check to happen.