### PR TITLE
Use 5 second timeout on initial connection to KDC

### DIFF
--- a/client/network.go
+++ b/client/network.go
@@ -77,7 +77,7 @@ func dialKDCUDP(count int, kdcs map[int]string) (*net.UDPConn, error) {
 			return nil, fmt.Errorf("error resolving KDC address: %v", err)
 		}
 
-		conn, err := net.DialTimeout("udp", upAddr.String(), 5*time.Second)
+		conn, err := net.DialTimeout("udp", udpAddr.String(), 5*time.Second)
 		if err == nil {
 			if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
 				return nil, err

--- a/client/network.go
+++ b/client/network.go
@@ -77,8 +77,7 @@ func dialKDCUDP(count int, kdcs map[int]string) (*net.UDPConn, error) {
 			return nil, fmt.Errorf("error resolving KDC address: %v", err)
 		}
 
-		addr := fmt.Sprintf("%s", udpAddr)
-		conn, err := net.DialTimeout("udp", addr, 5*time.Second)
+		conn, err := net.DialTimeout("udp", upAddr.String(), 5*time.Second)
 		if err == nil {
 			if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
 				return nil, err
@@ -100,8 +99,7 @@ func dialKDCTCP(count int, kdcs map[int]string) (*net.TCPConn, error) {
 			return nil, fmt.Errorf("error resolving KDC address: %v", err)
 		}
 
-		addr := fmt.Sprintf("%s", tcpAddr)
-		conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
+		conn, err := net.DialTimeout("tcp", tcpAddr.String(), 5*time.Second)
 		if err == nil {
 			if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
 				return nil, err

--- a/client/network.go
+++ b/client/network.go
@@ -69,49 +69,49 @@ func (cl *Client) sendToKDC(b []byte, realm string) ([]byte, error) {
 }
 
 // dialKDCTCP establishes a UDP connection to a KDC.
-func dialKDCUDP(count int, kdcs map[int]string) (conn *net.UDPConn, err error) {
+func dialKDCUDP(count int, kdcs map[int]string) (*net.UDPConn, error) {
 	i := 1
 	for i <= count {
-		udpAddr, e := net.ResolveUDPAddr("udp", kdcs[i])
-		if e != nil {
-			err = fmt.Errorf("error resolving KDC address: %v", e)
-			return
+		udpAddr, err := net.ResolveUDPAddr("udp", kdcs[i])
+		if err != nil {
+			return nil, fmt.Errorf("error resolving KDC address: %v", err)
 		}
-		conn, err = net.DialUDP("udp", nil, udpAddr)
+
+		addr := fmt.Sprintf("%s", udpAddr)
+		conn, err := net.DialTimeout("udp", addr, 5*time.Second)
 		if err == nil {
-			err = conn.SetDeadline(time.Now().Add(5 * time.Second))
-			if err != nil {
-				return
+			if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				return nil, err
 			}
-			return
+			// conn is guaranteed to be a UDPConn
+			return conn.(*net.UDPConn), nil
 		}
 		i++
 	}
-	err = errors.New("error in getting a UDP connection to any of the KDCs")
-	return
+	return nil, errors.New("error in getting a UDP connection to any of the KDCs")
 }
 
 // dialKDCTCP establishes a TCP connection to a KDC.
-func dialKDCTCP(count int, kdcs map[int]string) (conn *net.TCPConn, err error) {
+func dialKDCTCP(count int, kdcs map[int]string) (*net.TCPConn, error) {
 	i := 1
 	for i <= count {
-		tcpAddr, e := net.ResolveTCPAddr("tcp", kdcs[i])
-		if e != nil {
-			err = fmt.Errorf("error resolving KDC address: %v", e)
-			return
+		tcpAddr, err := net.ResolveTCPAddr("tcp", kdcs[i])
+		if err != nil {
+			return nil, fmt.Errorf("error resolving KDC address: %v", err)
 		}
-		conn, err = net.DialTCP("tcp", nil, tcpAddr)
+
+		addr := fmt.Sprintf("%s", tcpAddr)
+		conn, err := net.DialTimeout("tcp", addr, 5*time.Second)
 		if err == nil {
-			err = conn.SetDeadline(time.Now().Add(5 * time.Second))
-			if err != nil {
-				return
+			if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
+				return nil, err
 			}
-			return
+			// conn is guaranteed to be a TCPConn
+			return conn.(*net.TCPConn), nil
 		}
 		i++
 	}
-	err = errors.New("error in getting a TCP connection to any of the KDCs")
-	return
+	return nil, errors.New("error in getting a TCP connection to any of the KDCs")
 }
 
 // sendKDCUDP sends bytes to the KDC via UDP.


### PR DESCRIPTION
net.DialTCP() and net.DialUDP() don't allow specifying a timeout. This
means if the connection if a connection can't be established to the KDC
things hang until the OS timeout occurs which could be on the order of
minutes.

Instead, use net.DialTimeout() and specify a network (tcp, udp) and a
timeout of five seconds. This matches the read/write timeout set once
the connection has been established.