### PR TITLE
Respect KeytabPrincipal setting in VerifyAPREQ

### DIFF
--- a/v8/messages/APReq.go
+++ b/v8/messages/APReq.go
@@ -153,7 +153,7 @@ func (a *APReq) Marshal() ([]byte, error) {
 
 // Verify an AP_REQ using service's keytab, spn and max acceptable clock skew duration.
 // The service ticket encrypted part and authenticator will be decrypted as part of this operation.
-func (a *APReq) Verify(kt *keytab.Keytab, d time.Duration, cAddr types.HostAddress) (bool, error) {
+func (a *APReq) Verify(kt *keytab.Keytab, d time.Duration, cAddr types.HostAddress, snameOverride *types.PrincipalName) (bool, error) {
 	// Decrypt ticket's encrypted part with service key
 	//TODO decrypt with service's session key from its TGT is use-to-user. Need to figure out how to get TGT.
 	//if types.IsFlagSet(&a.APOptions, flags.APOptionUseSessionKey) {
@@ -178,7 +178,11 @@ func (a *APReq) Verify(kt *keytab.Keytab, d time.Duration, cAddr types.HostAddre
 	//		return false, krberror.Errorf(err, krberror.DecryptingError, "error decrypting encpart of service ticket provided")
 	//	}
 	//}
-	err := a.Ticket.DecryptEncPart(kt, &a.Ticket.SName)
+	sname := &a.Ticket.SName
+	if snameOverride != nil {
+		sname = snameOverride
+	}
+	err := a.Ticket.DecryptEncPart(kt, sname)
 	if err != nil {
 		return false, krberror.Errorf(err, krberror.DecryptingError, "error decrypting encpart of service ticket provided")
 	}

--- a/v8/service/APExchange.go
+++ b/v8/service/APExchange.go
@@ -11,7 +11,7 @@ import (
 // VerifyAPREQ verifies an AP_REQ sent to the service. Returns a boolean for if the AP_REQ is valid and the client's principal name and realm.
 func VerifyAPREQ(APReq *messages.APReq, s *Settings) (bool, *credentials.Credentials, error) {
 	var creds *credentials.Credentials
-	ok, err := APReq.Verify(s.Keytab, s.MaxClockSkew(), s.ClientAddress())
+	ok, err := APReq.Verify(s.Keytab, s.MaxClockSkew(), s.ClientAddress(), s.KeytabPrincipal())
 	if err != nil || !ok {
 		return false, creds, err
 	}


### PR DESCRIPTION
Fixes #330 

This PR allows a caller to override the keytab principal used in `VerifyAPREQ`. Since this method is used by the `SPNEGOKRB5Authenticate` function, this fixes the issue in the linked ticket where the given keytab principal was being ignored.

Please let me know if this is not the right approach, and a thank-you in advance to the maintainers of this repo!