### PR TITLE
keytabs: add entries

### DIFF
--- a/v8/keytab/keytab.go
+++ b/v8/keytab/keytab.go
@@ -9,6 +9,7 @@ import (
 	"fmt"
 	"io"
 	"io/ioutil"
+	"strings"
 	"time"
 	"unsafe"
 
@@ -54,18 +55,7 @@ type principal struct {
 }
 
 func (p principal) String() string {
-	var s string
-	if len(p.Components) == 0 {
-		s = ""
-	} else {
-		s = p.Components[0]
-	}
-
-	if len(p.Components) == 2 {
-		s += fmt.Sprintf("/%s", p.Components[1])
-	}
-	s += fmt.Sprintf("@%s", p.Realm)
-	return s
+	return fmt.Sprintf("%s@%s", strings.Join(p.Components, "/"), p.Realm)
 }
 
 // New creates new, empty Keytab type.

--- a/v8/keytab/keytab.go
+++ b/v8/keytab/keytab.go
@@ -23,7 +23,7 @@ const (
 
 // Keytab struct.
 type Keytab struct {
-	Version uint8
+	version uint8
 	Entries []entry
 }
 
@@ -62,7 +62,7 @@ func (p principal) String() string {
 func New() *Keytab {
 	var e []entry
 	return &Keytab{
-		Version: 0,
+		version: 2,
 		Entries: e,
 	}
 }
@@ -135,7 +135,7 @@ func (k *Keytab) AddEntry(principalName, realm, password string, ts time.Time, K
 	// Populate the keytab entry principal
 	ktep := newPrincipal()
 	ktep.NumComponents = int16(len(princ.NameString))
-	if k.Version == 1 {
+	if k.version == 1 {
 		ktep.NumComponents += 1
 	}
 
@@ -179,9 +179,9 @@ func Load(ktPath string) (*Keytab, error) {
 
 // Marshal keytab into byte slice
 func (kt *Keytab) Marshal() ([]byte, error) {
-	b := []byte{keytabFirstByte, kt.Version}
+	b := []byte{keytabFirstByte, kt.version}
 	for _, e := range kt.Entries {
-		eb, err := e.marshal(int(kt.Version))
+		eb, err := e.marshal(int(kt.version))
 		if err != nil {
 			return b, err
 		}
@@ -212,14 +212,14 @@ func (kt *Keytab) Unmarshal(b []byte) error {
 	}
 	//Get keytab version
 	//The 2nd byte contains the version number (1 or 2)
-	kt.Version = b[1]
-	if kt.Version != 1 && kt.Version != 2 {
+	kt.version = b[1]
+	if kt.version != 1 && kt.version != 2 {
 		return errors.New("invalid keytab data. Keytab version is neither 1 nor 2")
 	}
 	//Version 1 of the file format uses native byte order for integer representations. Version 2 always uses big-endian byte order
 	var endian binary.ByteOrder
 	endian = binary.BigEndian
-	if kt.Version == 1 && isNativeEndianLittle() {
+	if kt.version == 1 && isNativeEndianLittle() {
 		endian = binary.LittleEndian
 	}
 	// n tracks position in the byte array
@@ -348,7 +348,7 @@ func parsePrincipal(b []byte, p *int, kt *Keytab, ke *entry, e *binary.ByteOrder
 	if err != nil {
 		return err
 	}
-	if kt.Version == 1 {
+	if kt.version == 1 {
 		//In version 1 the number of components includes the realm. Minus 1 to make consistent with version 2
 		ke.Principal.NumComponents--
 	}
@@ -372,7 +372,7 @@ func parsePrincipal(b []byte, p *int, kt *Keytab, ke *entry, e *binary.ByteOrder
 		}
 		ke.Principal.Components = append(ke.Principal.Components, string(compB))
 	}
-	if kt.Version != 1 {
+	if kt.version != 1 {
 		//Name Type is omitted in version 1
 		ke.Principal.NameType, err = readInt32(b, p, e)
 		if err != nil {

--- a/v8/keytab/keytab.go
+++ b/v8/keytab/keytab.go
@@ -136,7 +136,7 @@ func (k Keytab) String() string {
 	return s
 }
 
-// AddEntry adds an entry to the keytab. The password should be  provided in plain text as it will be derived to be stored as a key using the provided enctype.
+// AddEntry adds an entry to the keytab. The password should be provided in plain text and it will be converted using the defined enctype to be stored.
 func (k *Keytab) AddEntry(principalName, realm, password string, ts time.Time, KVNO uint8, encType int32, pads types.PADataSequence) error {
 	var ktep principal
 	var princ types.PrincipalName

--- a/v8/keytab/keytab.go
+++ b/v8/keytab/keytab.go
@@ -124,10 +124,10 @@ func (k Keytab) String() string {
 }
 
 // AddEntry adds an entry to the keytab. The password should be provided in plain text and it will be converted using the defined enctype to be stored.
-func (k *Keytab) AddEntry(principalName, realm, password string, ts time.Time, KVNO uint8, encType int32, pads types.PADataSequence) error {
+func (k *Keytab) AddEntry(principalName, realm, password string, ts time.Time, KVNO uint8, encType int32) error {
 	// Generate a key from the password
 	princ, _ := types.ParseSPNString(principalName)
-	key, _, err := crypto.GetKeyFromPassword(password, princ, realm, encType, pads)
+	key, _, err := crypto.GetKeyFromPassword(password, princ, realm, encType, types.PADataSequence{})
 	if err != nil {
 		return err
 	}

--- a/v8/keytab/keytab.go
+++ b/v8/keytab/keytab.go
@@ -117,11 +117,8 @@ func (k Keytab) String() string {
 	s = `KVNO Timestamp         Principal                                                ET Key
 ---- ----------------- -------------------------------------------------------- -- ----------------------------------------------------------------
 `
-
-	if len(k.Entries) > 0 {
-		for _, entry := range k.Entries {
-			s += entry.String() + "\n"
-		}
+	for _, entry := range k.Entries {
+		s += entry.String() + "\n"
 	}
 	return s
 }

--- a/v8/keytab/keytab.go
+++ b/v8/keytab/keytab.go
@@ -125,21 +125,15 @@ func (k Keytab) String() string {
 
 // AddEntry adds an entry to the keytab. The password should be provided in plain text and it will be converted using the defined enctype to be stored.
 func (k *Keytab) AddEntry(principalName, realm, password string, ts time.Time, KVNO uint8, encType int32, pads types.PADataSequence) error {
-	var ktep principal
-	var princ types.PrincipalName
-	var key types.EncryptionKey
-	var e entry
-	var err error
-
 	// Generate a key from the password
-	princ, _ = types.ParseSPNString(principalName)
-	key, _, err = crypto.GetKeyFromPassword(password, princ, realm, encType, pads)
+	princ, _ := types.ParseSPNString(principalName)
+	key, _, err := crypto.GetKeyFromPassword(password, princ, realm, encType, pads)
 	if err != nil {
 		return err
 	}
 
 	// Populate the keytab entry principal
-	ktep = newPrincipal()
+	ktep := newPrincipal()
 	ktep.NumComponents = int16(len(princ.NameString))
 	if k.Version == 1 {
 		ktep.NumComponents += 1
@@ -149,10 +143,8 @@ func (k *Keytab) AddEntry(principalName, realm, password string, ts time.Time, K
 	ktep.Components = princ.NameString
 	ktep.NameType = princ.NameType
 
-	princ, _ = types.ParseSPNString(principalName)
-
 	// Populate the keytab entry
-	e = newEntry()
+	e := newEntry()
 	e.Principal = ktep
 	e.Timestamp = ts
 	e.KVNO8 = KVNO

--- a/v8/keytab/keytab_test.go
+++ b/v8/keytab/keytab_test.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/jcmturner/gokrb5/v8/iana/etypeID"
 	"github.com/jcmturner/gokrb5/v8/test/testdata"
-	"github.com/jcmturner/gokrb5/v8/types"
 	"github.com/stretchr/testify/assert"
 )
 
@@ -171,7 +170,7 @@ func TestKeytabEntriesUser(t *testing.T) {
 
 	kt := New()
 	for _, et := range encTypes {
-		err = kt.AddEntry("user", "EXAMPLE.ORG", "hello123", ts, uint8(31), et, types.PADataSequence{})
+		err = kt.AddEntry("user", "EXAMPLE.ORG", "hello123", ts, uint8(31), et)
 		if err != nil {
 			t.Errorf("Error adding entry to keytab: %s", err)
 		}
@@ -209,7 +208,7 @@ func TestKeytabEntriesService(t *testing.T) {
 
 	kt := New()
 	for _, et := range encTypes {
-		err = kt.AddEntry("HTTP/www.example.org", "EXAMPLE.ORG", "hello456", ts, uint8(10), et, types.PADataSequence{})
+		err = kt.AddEntry("HTTP/www.example.org", "EXAMPLE.ORG", "hello456", ts, uint8(10), et)
 		if err != nil {
 			t.Errorf("Error adding entry to keytab: %s", err)
 		}

--- a/v8/keytab/keytab_test.go
+++ b/v8/keytab/keytab_test.go
@@ -23,7 +23,7 @@ func TestUnmarshal(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Error parsing keytab data: %v\n", err)
 	}
-	assert.Equal(t, uint8(2), kt.Version, "Keytab version not as expected")
+	assert.Equal(t, uint8(2), kt.version, "Keytab version not as expected")
 	assert.Equal(t, uint32(1), kt.Entries[0].KVNO, "KVNO not as expected")
 	assert.Equal(t, uint8(1), kt.Entries[0].KVNO8, "KVNO8 not as expected")
 	assert.Equal(t, time.Unix(1505669592, 0), kt.Entries[0].Timestamp, "Timestamp not as expected")
@@ -68,7 +68,7 @@ func TestLoad(t *testing.T) {
 	if err != nil {
 		t.Fatalf("could not load keytab: %v", err)
 	}
-	assert.Equal(t, uint8(2), kt.Version, "keytab version not as expected")
+	assert.Equal(t, uint8(2), kt.version, "keytab version not as expected")
 	assert.Equal(t, 12, len(kt.Entries), "keytab entry count not as expected: %+v", *kt)
 	for _, e := range kt.Entries {
 		if e.Principal.Realm != "TEST.GOKRB5" {
@@ -170,7 +170,6 @@ func TestKeytabEntriesUser(t *testing.T) {
 	}
 
 	kt := New()
-	kt.Version = 2
 	for _, et := range encTypes {
 		err = kt.AddEntry("user", "EXAMPLE.ORG", "hello123", ts, uint8(31), et, types.PADataSequence{})
 		if err != nil {
@@ -209,7 +208,6 @@ func TestKeytabEntriesService(t *testing.T) {
 	}
 
 	kt := New()
-	kt.Version = 2
 	for _, et := range encTypes {
 		err = kt.AddEntry("HTTP/www.example.org", "EXAMPLE.ORG", "hello456", ts, uint8(10), et, types.PADataSequence{})
 		if err != nil {


### PR DESCRIPTION
As discussed in #376, this PR adds an `AddEntry` method so we can create and save keytabs.

It is currently used as follows. There might be cleaner ways to set the keytab version.
```
kt := keytab.New()
kt.Version = 2
err = kt.AddEntry(princName, realm, password, time.Now(), uint8(0), etypeID.AES256_CTS_HMAC_SHA1_96, types.PADataSequence{})
err = kt.AddEntry(princName, realm, password, time.Now(), uint8(0), etypeID.AES128_CTS_HMAC_SHA1_96, types.PADataSequence{})
err = kt.AddEntry(princName, realm, password, time.Now(), uint8(0), etypeID.RC4_HMAC, types.PADataSequence{})
```

I also added `String()` methods following the ktutil format that were very useful in debugging.

The tests compare the generated keytabs against `ktutil` keytabs.