### PR TITLE
client: Fix Dropped Errors

### DIFF
--- a/client/passwd.go
+++ b/client/passwd.go
@@ -76,6 +76,9 @@ func (cl *Client) sendKPasswdTCP(b []byte, kadmindAddr string) (r kadmin.Reply, 
 		return
 	}
 	rb, err := cl.sendTCP(conn, b)
+	if err != nil {
+		return
+	}
 	err = r.Unmarshal(rb)
 	return
 }

--- a/client/passwd.go
+++ b/client/passwd.go
@@ -90,6 +90,9 @@ func (cl *Client) sendKPasswdUDP(b []byte, kadmindAddr string) (r kadmin.Reply, 
 		return
 	}
 	rb, err := cl.sendUDP(conn, b)
+	if err != nil {
+		return
+	}
 	err = r.Unmarshal(rb)
 	return
 }


### PR DESCRIPTION
This PR fixes two dropped errors in the `client` package.

I put each fix into its own commit should someone need to bisect back to this change in the future. I can squash them into one commit, if that is the preferred style here.
