### PR TITLE
Redefine marshalNegTokenInit.ReqFlags as asn1.BitString

### DIFF
--- a/v8/spnego/negotiationToken.go
+++ b/v8/spnego/negotiationToken.go
@@ -38,7 +38,7 @@ type NegTokenInit struct {
 
 type marshalNegTokenInit struct {
 	MechTypes      []asn1.ObjectIdentifier `asn1:"explicit,tag:0"`
-	ReqFlags       gssapi.ContextFlags     `asn1:"explicit,optional,tag:1"`
+	ReqFlags       asn1.BitString          `asn1:"explicit,optional,tag:1"`
 	MechTokenBytes []byte                  `asn1:"explicit,optional,omitempty,tag:2"`
 	MechListMIC    []byte                  `asn1:"explicit,optional,omitempty,tag:3"` // This field is not used when negotiating Kerberos tokens
 }
@@ -67,7 +67,7 @@ type NegTokenTarg NegTokenResp
 func (n *NegTokenInit) Marshal() ([]byte, error) {
 	m := marshalNegTokenInit{
 		MechTypes:      n.MechTypes,
-		ReqFlags:       n.ReqFlags,
+		ReqFlags:       (asn1.BitString)(n.ReqFlags),
 		MechTokenBytes: n.MechTokenBytes,
 		MechListMIC:    n.MechListMIC,
 	}
@@ -261,7 +261,7 @@ func UnmarshalNegToken(b []byte) (bool, interface{}, error) {
 		}
 		nt := NegTokenInit{
 			MechTypes:      n.MechTypes,
-			ReqFlags:       n.ReqFlags,
+			ReqFlags:       (gssapi.ContextFlags)(n.ReqFlags),
 			MechTokenBytes: n.MechTokenBytes,
 			MechListMIC:    n.MechListMIC,
 		}


### PR DESCRIPTION
Change the defintion of ReqFlags from gssapi.ContextFlags (which is
itself a type alias for asn1.BitString) to an asn1.BitString directly.

This allows the asn1 type reflection to correctly identify the ReqFlags
field as a type 3 bitstring rather than a type 16 sequence, and will
parse the value of the ReqFlags field correctly. Without this change,
the parser will fail to interpret an `asn1:"explicit,optional,tag:1`
field without skipping the byte offset past the field, and such all
following tags will also fail to be parsed correctly.

Since the field has the same underlying datatype, it can be casted
to the relevant one in each direction to maintain the same behaviour
whilst also resolving the type reflection mis-identification.

Fixes #390