### PR TITLE
fix neg token unmarshal when req flags are present

### DIFF
--- a/v8/gssapi/contextFlags.go
+++ b/v8/gssapi/contextFlags.go
@@ -14,9 +14,11 @@ const (
 )
 
 // ContextFlags flags for GSSAPI
+// DEPRECATED - do not use
 type ContextFlags asn1.BitString
 
-// NewContextFlags creates a new ContextFlags instance.
+// NewContextFlags creates a new ContextFlags instance
+// DEPRECATED - do not use
 func NewContextFlags() ContextFlags {
 	var c ContextFlags
 	c.BitLength = 32

--- a/v8/spnego/negotiationToken.go
+++ b/v8/spnego/negotiationToken.go
@@ -29,7 +29,7 @@ type NegState int
 // NegTokenInit implements Negotiation Token of type Init.
 type NegTokenInit struct {
 	MechTypes      []asn1.ObjectIdentifier
-	ReqFlags       gssapi.ContextFlags
+	ReqFlags       asn1.BitString
 	MechTokenBytes []byte
 	MechListMIC    []byte
 	mechToken      gssapi.ContextToken
@@ -38,7 +38,7 @@ type NegTokenInit struct {
 
 type marshalNegTokenInit struct {
 	MechTypes      []asn1.ObjectIdentifier `asn1:"explicit,tag:0"`
-	ReqFlags       gssapi.ContextFlags     `asn1:"explicit,optional,tag:1"`
+	ReqFlags       asn1.BitString          `asn1:"explicit,optional,tag:1"`
 	MechTokenBytes []byte                  `asn1:"explicit,optional,omitempty,tag:2"`
 	MechListMIC    []byte                  `asn1:"explicit,optional,omitempty,tag:3"` // This field is not used when negotiating Kerberos tokens
 }

--- a/v8/spnego/negotiationToken_test.go
+++ b/v8/spnego/negotiationToken_test.go
@@ -88,3 +88,20 @@ func TestMarshal_negTokenResp(t *testing.T) {
 	}
 	assert.Equal(t, b, mb, "Marshalled bytes not as expected for NegTokenResp")
 }
+
+func TestUnmarshal_negTokenInitWithReqFlags(t *testing.T) {
+	mhex := "a01e301ca00d300b06092a864886f712010202a10403020176a2050403010203"
+	mb, err := hex.DecodeString(mhex)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	var m NegTokenInit
+	err = m.Unmarshal(mb)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(m.MechTokenBytes) != 3 {
+		t.Errorf("unmarshal did not return the correct number of mechToken bytes")
+	}
+}


### PR DESCRIPTION
Removed the use of the type gssapi.ContextFlags. Making use of asn1.BitString instead as the the ContextFlags was causing an issue with the asn1 marshaling.