### PR TITLE
Don't use the default realm for TGS requests

### DIFF
--- a/v8/client/TGSExchange.go
+++ b/v8/client/TGSExchange.go
@@ -89,7 +89,12 @@ func (cl *Client) GetServiceTicket(spn string) (messages.Ticket, types.Encryptio
 		return tkt, skey, nil
 	}
 	princ := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, spn)
-	realm := cl.Config.ResolveRealm(princ.NameString[len(princ.NameString)-1])
+	realm := cl.spnRealm(princ)
+
+	// if we don't know the SPN's realm, ask the client realm's KDC
+	if realm == "" {
+		realm = cl.Credentials.Realm()
+	}
 
 	tgt, skey, err := cl.sessionTGT(realm)
 	if err != nil {

--- a/v8/client/session.go
+++ b/v8/client/session.go
@@ -41,7 +41,9 @@ func (s *sessions) update(sess *session) {
 			// Cancel the one in the cache and add this one.
 			i.mux.Lock()
 			defer i.mux.Unlock()
-			i.cancel <- true
+			if i.cancel != nil {
+				i.cancel <- true
+			}
 			s.Entries[sess.realm] = sess
 			return
 		}
@@ -291,5 +293,11 @@ func (cl *Client) sessionTimes(realm string) (authTime, endTime, renewTime, sess
 
 // spnRealm resolves the realm name of a service principal name
 func (cl *Client) spnRealm(spn types.PrincipalName) string {
-	return cl.Config.ResolveRealm(spn.NameString[len(spn.NameString)-1])
+	// Is thre a domain/realm mapping for the spn's domain ?
+
+	// We don't want to use the default realm, that isn't meant to be used
+	// for TGS requests.  The caller should ask the client's realm if the
+	// config doesn't specify one
+
+	return cl.Config.ResolveRealm(spn.NameString[len(spn.NameString)-1], false)
 }

--- a/v8/config/krb5conf.go
+++ b/v8/config/krb5conf.go
@@ -490,8 +490,9 @@ func (d *DomainRealm) deleteMapping(domain, realm string) {
 }
 
 // ResolveRealm resolves the kerberos realm for the specified domain name from the domain to realm mapping.
-// The most specific mapping is returned.
-func (c *Config) ResolveRealm(domainName string) string {
+// The most specific mapping is returned.  If none is found, the default realm is returned, unless
+// useDefault is false
+func (c *Config) ResolveRealm(domainName string, useDefault bool) string {
 	domainName = strings.TrimSuffix(domainName, ".")
 
 	// Try to match the entire hostname first
@@ -507,7 +508,11 @@ func (c *Config) ResolveRealm(domainName string) string {
 			return r
 		}
 	}
-	return c.LibDefaults.DefaultRealm
+
+	if useDefault {
+		return c.LibDefaults.DefaultRealm
+	}
+	return ""
 }
 
 // Load the KRB5 configuration from the specified file path.

--- a/v8/config/krb5conf_test.go
+++ b/v8/config/krb5conf_test.go
@@ -646,18 +646,22 @@ func TestResolveRealm(t *testing.T) {
 
 	tests := []struct {
 		domainName string
+		useDefault bool
 		want       string
 	}{
-		{"unknown.com", "TEST.GOKRB5"},
-		{"hostname1.example.com", "EXAMPLE.COM"},
-		{"hostname2.example.com", "TEST.GOKRB5"},
-		{"one.two.three.example.com", "EXAMPLE.COM"},
-		{".test.gokrb5", "TEST.GOKRB5"},
-		{"foo.testlowercase.org", "lowercase.org"},
+		{"unknown.com", true, "TEST.GOKRB5"},
+		{"unknown.com", false, ""},
+		{"hostname1.example.com", true, "EXAMPLE.COM"},
+		{"hostname1.example.com", false, "EXAMPLE.COM"},
+		{"hostname2.example.com", true, "TEST.GOKRB5"},
+		{"hostname2.example.com", false, "TEST.GOKRB5"},
+		{"one.two.three.example.com", true, "EXAMPLE.COM"},
+		{".test.gokrb5", true, "TEST.GOKRB5"},
+		{"foo.testlowercase.org", true, "lowercase.org"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.domainName, func(t *testing.T) {
-			if got := c.ResolveRealm(tt.domainName); got != tt.want {
+			if got := c.ResolveRealm(tt.domainName, tt.useDefault); got != tt.want {
 				t.Errorf("config.ResolveRealm() = %v, want %v", got, tt.want)
 			}
 		})


### PR DESCRIPTION
Fixes #424

The default realm isn't used by the MIT library for TGS requests.. the domain/realm mapping is consulted and if that doesn't yield results, the client's realm is asked for the ticket (unless there is a start_realm config item in the creds cache).  So if my default_realm is FOO.COM, and I 'kinit me@BAR.COM', then a request for HTTP/webserver.domain.com  should ask the BAR.COM KDC if there is no entry for .domain.com or webserver.domain.com in the config.

Also don't try to cancel a non-existent refresh goroutine when updating the session cache.  There are no goroutines for entries that come from the ccache.