### PR TITLE
Limit generated sequence numbers to 2^30 for compatibility

### DIFF
--- a/v8/types/Authenticator.go
+++ b/v8/types/Authenticator.go
@@ -43,7 +43,7 @@ func NewAuthenticator(realm string, cname PrincipalName) (Authenticator, error) 
 		Cksum:     Checksum{},
 		Cusec:     int((t.UnixNano() / int64(time.Microsecond)) - (t.Unix() * 1e6)),
 		CTime:     t,
-		SeqNumber: seq.Int64(),
+		SeqNumber: seq.Int64() & 0x3fffffff,
 	}, nil
 }
 
@@ -53,7 +53,7 @@ func (a *Authenticator) GenerateSeqNumberAndSubKey(keyType int32, keySize int) e
 	if err != nil {
 		return err
 	}
-	a.SeqNumber = seq.Int64()
+	a.SeqNumber = seq.Int64() & 0x3fffffff
 	//Generate subkey value
 	sk := make([]byte, keySize, keySize)
 	rand.Read(sk)


### PR DESCRIPTION
Fixes #434

As per MIT source (src/lib/krb5/krb/gen_seqnum.c) :
    /*
     * Work around implementation incompatibilities by not generating
     * initial sequence numbers greater than 2^30.  Previous MIT
     * implementations use signed sequence numbers, so initial
     * sequence numbers 2^31 to 2^32-1 inclusive will be rejected.
     * Letting the maximum initial sequence number be 2^30-1 allows
     * for about 2^30 messages to be sent before wrapping into
     * "negative" numbers.
     */

.. and information provided on the kerberos@mit.edu mailing list :

Greg Hudson <ghudson@mit.edu>
Mar 26, 2021, 5:17 PM

On 3/26/21 3:26 PM, Jake Scott wrote:
> I took the naive approach of handling the initial sequence numbers by
> simply casting the uint32 value from the authenticator and AP-REP encpart
> to uint64.  However that causes compatibility issues with the MIT
> implementation that appears to cast first to a signed int32 and then to the
> GSSAPI uint64.

I think that may have been a bug introduced in 2008.  In release 1.6,
the GSSAPI code fetched the Kerberos sequence number into a uint32, but
using a function accepting an int32 *, which caused compiler warnings.
Commit abcfdaff756631d73f49103f679cafa7bc45f14e (later merged in commit
0ba5ccd7bb3ea15e44a87f84ca6feed8890f657d) the warnings were squashed by
changing the variable to an int32, apparently without regard to the
behavior change for Kerberos sequence numbers in the 2^31..2^32-1 range.

Due to earlier history with sequence number and ASN.1 encoding bugs, MIT
and Heimdal both generate Kerberos sequence numbers in the range
0..2^30-1 by masking with 0x3FFFFFFF (see krb5_generate_seq_number() in
both implementations).  I would speculate that Microsoft and Java do the
same.  That could explain why the behavior change might have gone unnoticed.