### PR TITLE
add TCP dialTimeout logs

### DIFF
--- a/client/network.go
+++ b/client/network.go
@@ -7,7 +7,6 @@ import (
 	"fmt"
 	"io"
 	"net"
-	"strings"
 	"time"
 
 	"gopkg.in/jcmturner/gokrb5.v7/iana/errorcode"
@@ -94,7 +93,6 @@ func dialKDCUDP(count int, kdcs map[int]string) (*net.UDPConn, error) {
 // dialKDCTCP establishes a TCP connection to a KDC.
 func dialKDCTCP(count int, kdcs map[int]string) (*net.TCPConn, error) {
 	i := 1
-	var dialTimeoutErrors []string
 	for i <= count {
 		tcpAddr, err := net.ResolveTCPAddr("tcp", kdcs[i])
 		if err != nil {
@@ -102,7 +100,6 @@ func dialKDCTCP(count int, kdcs map[int]string) (*net.TCPConn, error) {
 		}
 
 		conn, err := net.DialTimeout("tcp", tcpAddr.String(), 5*time.Second)
-
 		if err == nil {
 			if err := conn.SetDeadline(time.Now().Add(5 * time.Second)); err != nil {
 				return nil, err
@@ -110,13 +107,7 @@ func dialKDCTCP(count int, kdcs map[int]string) (*net.TCPConn, error) {
 			// conn is guaranteed to be a TCPConn
 			return conn.(*net.TCPConn), nil
 		}
-		dialTimeoutErrors = append(dialTimeoutErrors, err.Error())
 		i++
-	}
-
-	if len(dialTimeoutErrors) > 0 {
-		dialTimeoutError := "'" + strings.Join(dialTimeoutErrors, ",") + "'"
-		return nil, fmt.Errorf("DialTimeout Error: %v", dialTimeoutError)
 	}
 	return nil, errors.New("error in getting a TCP connection to any of the KDCs")
 }

--- a/v8/client/network.go
+++ b/v8/client/network.go
@@ -2,7 +2,6 @@ package client
 
 import (
 	"encoding/binary"
-	"errors"
 	"fmt"
 	"io"
 	"net"

--- a/v8/client/network.go
+++ b/v8/client/network.go
@@ -173,11 +173,7 @@ func dialSendTCP(kdcs map[int]string, b []byte) ([]byte, error) {
 		}
 		return rb, nil
 	}
-	if len(errs) > 0 {
-		errorString := strings.Join(errs, ",")
-		return nil, fmt.Errorf("error in getting a TCP connection to any of the KDCs: %v", errorString)
-	}
-	return nil, errors.New("error in getting a TCP connection to any of the KDCs")
+	return nil, fmt.Errorf("error sending to a KDC: %s", strings.Join(errs, "; "))
 }
 
 // sendTCP sends bytes to connection over TCP.

--- a/v8/client/network.go
+++ b/v8/client/network.go
@@ -173,6 +173,10 @@ func dialSendTCP(kdcs map[int]string, b []byte) ([]byte, error) {
 		}
 		return rb, nil
 	}
+	if len(errs) > 0 {
+		errorString := strings.Join(errs, ",")
+		return nil, fmt.Errorf("error in getting a TCP connection to any of the KDCs: %v", errorString)
+	}
 	return nil, errors.New("error in getting a TCP connection to any of the KDCs")
 }
 


### PR DESCRIPTION
For our use case we had KDC ip being assigned through an automation script.

The method here https://github.com/jcmturner/gokrb5/blob/663478bf457f1fc3275973bea5b7b787cd332015/v8/client/network.go#L150-L151
had the array **errs** storing all the errors thrown during tcp connection but was not using them anywhere, didn't log them nor append them to the error stack trace, but just threw a generic error here at https://github.com/jcmturner/gokrb5/blob/663478bf457f1fc3275973bea5b7b787cd332015/v8/client/network.go#L176 without capturing any relevant info especially the IP of the machine. So have just appended the **err** to the error stack trace as this made it difficult to pinpoint the exact reason/IP of the machine that was down. 

