### PR TITLE
Treat an address slice containing only a NetBIOS address as empty

### DIFF
--- a/types/HostAddress.go
+++ b/types/HostAddress.go
@@ -139,7 +139,13 @@ func HostAddressesEqual(h, a []HostAddress) bool {
 }
 
 // HostAddressesContains tests if a HostAddress is contained in a HostAddress slice.
+// Treat an address slice containing only a NetBIOS addresses
+// as empty, because we presently have no way of associating
+// a client with its NetBIOS address.
 func HostAddressesContains(h []HostAddress, a HostAddress) bool {
+	if len(h) == 1 && h[0].AddrType == addrtype.NetBios {
+		return true
+	}
 	for _, e := range h {
 		if e.Equal(a) {
 			return true

--- a/v8/types/HostAddress.go
+++ b/v8/types/HostAddress.go
@@ -139,7 +139,13 @@ func HostAddressesEqual(h, a []HostAddress) bool {
 }
 
 // HostAddressesContains tests if a HostAddress is contained in a HostAddress slice.
+// Treat an address slice containing only a NetBIOS addresses
+// as empty, because we presently have no way of associating
+// a client with its NetBIOS address.
 func HostAddressesContains(h []HostAddress, a HostAddress) bool {
+	if len(h) == 1 && h[0].AddrType == addrtype.NetBios {
+		return true
+	}
 	for _, e := range h {
 		if e.Equal(a) {
 			return true


### PR DESCRIPTION
As there is no way to associate a client with its NetBIOS name treat the address slice as empty if it only contains a NetBIOS address.

This make the behavior equivalent to MIT Kerberos.