### PR TITLE
Implement the necessary functionalities for implementing a GSS-API server

### DIFF
--- a/v8/client/TGSExchange.go
+++ b/v8/client/TGSExchange.go
@@ -96,7 +96,7 @@ func (cl *Client) GetServiceTicket(spn string) (messages.Ticket, types.Encryptio
 		realm = cl.Credentials.Realm()
 	}
 
-	tgt, skey, err := cl.sessionTGT(realm)
+	tgt, _, skey, err := cl.sessionTGT(realm)
 	if err != nil {
 		return tkt, skey, err
 	}

--- a/v8/client/session_test.go
+++ b/v8/client/session_test.go
@@ -3,7 +3,7 @@ package client
 import (
 	"encoding/hex"
 	"fmt"
-	"io"
+	"io/ioutil"
 	"os"
 	"runtime"
 	"sync"
@@ -55,12 +55,12 @@ func TestMultiThreadedClientSession(t *testing.T) {
 	for i := 0; i < 10; i++ {
 		go func() {
 			defer wg.Done()
-			tgt, _, err := cl.sessionTGT("TEST.GOKRB5")
+			tgt, _, _, err := cl.sessionTGT("TEST.GOKRB5")
 			if err != nil || tgt.Realm != "TEST.GOKRB5" {
 				t.Logf("error getting session: %v", err)
 			}
-			_, _, _, r, _ := cl.sessionTimes("TEST.GOKRB5")
-			fmt.Fprintf(io.Discard, "%v", r)
+			_, _, _, _, r, _ := cl.sessionTimes("TEST.GOKRB5")
+			fmt.Fprintf(ioutil.Discard, "%v", r)
 		}()
 		time.Sleep(time.Second)
 	}
@@ -90,7 +90,7 @@ func TestClient_AutoRenew_Goroutine(t *testing.T) {
 	n := runtime.NumGoroutine()
 	for i := 0; i < 24; i++ {
 		time.Sleep(time.Second * 5)
-		_, endTime, _, _, err := cl.sessionTimes("TEST.GOKRB5")
+		_, _, endTime, _, _, err := cl.sessionTimes("TEST.GOKRB5")
 		if err != nil {
 			t.Errorf("could not get client's session: %v", err)
 		}
@@ -123,6 +123,7 @@ func TestSessions_JSON(t *testing.T) {
 		e := &session{
 			realm:                realm,
 			authTime:             time.Unix(int64(0+i), 0).UTC(),
+			startTime:            time.Unix(int64(1+i), 0).UTC(),
 			endTime:              time.Unix(int64(10+i), 0).UTC(),
 			renewTill:            time.Unix(int64(20+i), 0).UTC(),
 			sessionKeyExpiration: time.Unix(int64(30+i), 0).UTC(),
@@ -137,6 +138,7 @@ func TestSessions_JSON(t *testing.T) {
   {
     "Realm": "test0",
     "AuthTime": "1970-01-01T00:00:00Z",
+    "StartTime": "1970-01-01T00:00:01Z",
     "EndTime": "1970-01-01T00:00:10Z",
     "RenewTill": "1970-01-01T00:00:20Z",
     "SessionKeyExpiration": "1970-01-01T00:00:30Z"
@@ -144,6 +146,7 @@ func TestSessions_JSON(t *testing.T) {
   {
     "Realm": "test1",
     "AuthTime": "1970-01-01T00:00:01Z",
+    "StartTime": "1970-01-01T00:00:02Z",
     "EndTime": "1970-01-01T00:00:11Z",
     "RenewTill": "1970-01-01T00:00:21Z",
     "SessionKeyExpiration": "1970-01-01T00:00:31Z"
@@ -151,6 +154,7 @@ func TestSessions_JSON(t *testing.T) {
   {
     "Realm": "test2",
     "AuthTime": "1970-01-01T00:00:02Z",
+    "StartTime": "1970-01-01T00:00:03Z",
     "EndTime": "1970-01-01T00:00:12Z",
     "RenewTill": "1970-01-01T00:00:22Z",
     "SessionKeyExpiration": "1970-01-01T00:00:32Z"

--- a/v8/messages/APRep.go
+++ b/v8/messages/APRep.go
@@ -1,11 +1,18 @@
 package messages
 
 import (
+	"crypto/rand"
 	"fmt"
+	"math"
+	"math/big"
 	"time"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/asn1tools"
+	"github.com/jcmturner/gokrb5/v8/crypto"
+	"github.com/jcmturner/gokrb5/v8/iana"
 	"github.com/jcmturner/gokrb5/v8/iana/asnAppTag"
+	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
 	"github.com/jcmturner/gokrb5/v8/iana/msgtype"
 	"github.com/jcmturner/gokrb5/v8/krberror"
 	"github.com/jcmturner/gokrb5/v8/types"
@@ -46,4 +53,85 @@ func (a *EncAPRepPart) Unmarshal(b []byte) error {
 		return krberror.Errorf(err, krberror.EncodingError, "AP_REP unmarshal error")
 	}
 	return nil
+}
+
+func (a *EncAPRepPart) Marshal() ([]byte, error) {
+	mk, err := asn1.Marshal(*a)
+	if err != nil {
+		return []byte{}, err
+	}
+	mk = asn1tools.AddASNAppTag(mk, asnAppTag.EncAPRepPart)
+	return mk, nil
+}
+
+func (a *APRep) Marshal() ([]byte, error) {
+	rep, err := asn1.Marshal(*a)
+	if err != nil {
+		return rep, err
+	}
+	rep = asn1tools.AddASNAppTag(rep, asnAppTag.APREP)
+	return rep, nil
+}
+
+func (a *EncAPRepPart) GenerateSeqNumber() error {
+	seq, err := rand.Int(rand.Reader, big.NewInt(math.MaxUint32))
+	if err != nil {
+		return err
+	}
+	a.SequenceNumber = seq.Int64()
+	return nil
+}
+
+func (a *APRep) DecryptEncryptedPart(sessionKey types.EncryptionKey) (EncAPRepPart, error) {
+	encPart := EncAPRepPart{}
+
+	ab, e := crypto.DecryptEncPart(a.EncPart, sessionKey, uint32(keyusage.AP_REP_ENCPART))
+	if e != nil {
+		return encPart, fmt.Errorf("error decrypting encrypted part: %v", e)
+	}
+	err := encPart.Unmarshal(ab)
+	if err != nil {
+		return encPart, fmt.Errorf("error unmarshaling encrypted part: %v", err)
+	}
+	return encPart, nil
+
+}
+
+func EncryptPart(tkt Ticket, sessionKey types.EncryptionKey, part EncAPRepPart) (types.EncryptedData, error) {
+	var ed types.EncryptedData
+	m, err := part.Marshal()
+	if err != nil {
+		return types.EncryptedData{}, krberror.Errorf(err, krberror.EncodingError, "marshaling error of EncryptedData form of APRep")
+	}
+
+	ed, err = crypto.GetEncryptedData(m, sessionKey, uint32(keyusage.AP_REP_ENCPART), tkt.EncPart.KVNO)
+	if err != nil {
+		return ed, krberror.Errorf(err, krberror.EncryptingError, "error encrypting APRepPart")
+	}
+	return ed, nil
+}
+
+func NewAPRep(tkt Ticket, authenticator types.Authenticator) (APRep, error) {
+	part := EncAPRepPart{
+		CTime: authenticator.CTime,
+		Cusec: authenticator.Cusec,
+	}
+	err := part.GenerateSeqNumber()
+	if err != nil {
+		return APRep{}, err
+	}
+	part.Subkey = authenticator.SubKey
+
+	ed, err := EncryptPart(tkt, tkt.DecryptedEncPart.Key, part)
+	//ed, err := encryptPart(tkt, authenticator.SubKey, part)
+	if err != nil {
+		return APRep{}, err
+	}
+
+	a := APRep{
+		PVNO:    iana.PVNO,
+		MsgType: msgtype.KRB_AP_REP,
+		EncPart: ed,
+	}
+	return a, nil
 }

--- a/v8/messages/KRBCred.go
+++ b/v8/messages/KRBCred.go
@@ -5,6 +5,7 @@ import (
 	"time"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/credentials"
 	"github.com/jcmturner/gokrb5/v8/crypto"
 	"github.com/jcmturner/gokrb5/v8/iana/asnAppTag"
 	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
@@ -52,6 +53,37 @@ type KrbCredInfo struct {
 	SRealm    string              `asn1:"optional,explicit,ia5,tag:8"`
 	SName     types.PrincipalName `asn1:"optional,explicit,tag:9"`
 	CAddr     types.HostAddresses `asn1:"optional,explicit,tag:10"`
+}
+
+func (k *KRBCred) ToCredentials() ([]credentials.Credential, error) {
+	c := make([]credentials.Credential, len(k.DecryptedEncPart.TicketInfo))
+
+	for i, tinfo := range k.DecryptedEncPart.TicketInfo {
+		cred := credentials.Credential{
+			Client: credentials.Principal{
+				Realm:         tinfo.PRealm,
+				PrincipalName: tinfo.PName,
+			},
+			Server: credentials.Principal{
+				Realm:         tinfo.SRealm,
+				PrincipalName: tinfo.SName,
+			},
+			Key:         tinfo.Key,
+			AuthTime:    tinfo.AuthTime,
+			StartTime:   tinfo.StartTime,
+			EndTime:     tinfo.EndTime,
+			RenewTill:   tinfo.RenewTill,
+			TicketFlags: tinfo.Flags,
+		}
+		ticket, err := k.Tickets[i].Marshal()
+		if err != nil {
+			return c, err
+		}
+		cred.Ticket = ticket
+		c[i] = cred
+	}
+
+	return c, nil
 }
 
 // Unmarshal bytes b into the KRBCred struct.

--- a/v8/spnego/http.go
+++ b/v8/spnego/http.go
@@ -232,8 +232,8 @@ const (
 	spnegoNegTokenRespIncompleteKRB5 = "Negotiate oRQwEqADCgEBoQsGCSqGSIb3EgECAg=="
 	// sessionCredentials is the session value key holding the credentials jcmturner/goidentity/Identity object.
 	sessionCredentials = "github.com/jcmturner/gokrb5/v8/sessionCredentials"
-	// ctxCredentials is the SPNEGO context key holding the credentials jcmturner/goidentity/Identity object.
-	ctxCredentials = "github.com/jcmturner/gokrb5/v8/ctxCredentials"
+	// CtxCredentials is the SPNEGO context key holding the credentials jcmturner/goidentity/Identity object.
+	CtxCredentials = "github.com/jcmturner/gokrb5/v8/ctxCredentials"
 	// HTTPHeaderAuthRequest is the header that will hold authn/z information.
 	HTTPHeaderAuthRequest = "Authorization"
 	// HTTPHeaderAuthResponse is the header that will hold SPNEGO data from the server.
@@ -287,7 +287,7 @@ func SPNEGOKRB5Authenticate(inner http.Handler, kt *keytab.Keytab, settings ...f
 
 		if authed {
 			// Authentication successful; get user's credentials from the context
-			id := ctx.Value(ctxCredentials).(*credentials.Credentials)
+			id := ctx.Value(CtxCredentials).(*credentials.Credentials)
 			// Create a new session if a session manager has been configured
 			err = newSession(spnego, r, w, id)
 			if err != nil {

--- a/v8/spnego/negotiationToken.go
+++ b/v8/spnego/negotiationToken.go
@@ -123,7 +123,7 @@ func (n *NegTokenInit) Verify() (bool, gssapi.Status) {
 	}
 	// There should be some mechtoken bytes for a KRB5Token (other mech types are not supported)
 	mt := new(KRB5Token)
-	mt.settings = n.settings
+	mt.Settings = n.settings
 	if n.mechToken == nil {
 		err := mt.Unmarshal(n.MechTokenBytes)
 		if err != nil {
@@ -202,7 +202,7 @@ func (n *NegTokenResp) Verify() (bool, gssapi.Status) {
 			return false, gssapi.Status{Code: gssapi.StatusContinueNeeded}
 		}
 		mt := new(KRB5Token)
-		mt.settings = n.settings
+		mt.Settings = n.settings
 		if n.mechToken == nil {
 			err := mt.Unmarshal(n.ResponseToken)
 			if err != nil {


### PR DESCRIPTION
This PR adds some necessary functionality for using gokrb5 in the server-side code of a GSS-API server.And some additional client-side functionality (i.e. writing and handling credential caches) Specifically:

* Creation and marshaling of APRep packets.
* Support for generating and serializing kerberos credential caches
*  Ability to get kerberos ticket from a credential delegation from the client, and embed it into the credential cache

The generated credential cache file format follows the [MIT standard](https://web.mit.edu/kerberos/krb5-devel/doc/formats/ccache_file_format.html)