### PR TITLE
Support for complex cross-realm scenarios

### DIFF
--- a/.github/workflows/testingv8.yml
+++ b/.github/workflows/testingv8.yml
@@ -54,6 +54,7 @@ jobs:
           sudo docker run -d -h kdc.test.gokrb5 -v /etc/localtime:/etc/localtime:ro -p 98:88 -p 98:88/udp --name krb5kdc-latest jcmturner/gokrb5:kdc-latest
           sudo docker run -d -h kdc.resdom.gokrb5 -v /etc/localtime:/etc/localtime:ro -p 188:88 -p 188:88/udp --name krb5kdc-resdom jcmturner/gokrb5:kdc-resdom
           sudo docker run -d -h kdc.test.gokrb5 -v /etc/localtime:/etc/localtime:ro -p 58:88 -p 58:88/udp --name krb5kdc-shorttickets jcmturner/gokrb5:kdc-shorttickets
+          sudo docker run -d -h kdc.sub.test.gokrb5 -v /etc/localtime:/etc/localtime:ro -p 288:88 -p 288:88/udp --name krb5kdc-sub jcmturner/gokrb5:kdc-sub
           sudo docker run -d --add-host host.test.gokrb5:127.0.0.88 -v /etc/localtime:/etc/localtime:ro -p 80:80 -p 443:443 --name gokrb5-http jcmturner/gokrb5:http
           sudo sed -i 's/nameserver .*/nameserver '${DNS_IP}'/g' /etc/resolv.conf
           dig _kerberos._udp.TEST.GOKRB5

--- a/v8/client/TGSExchange.go
+++ b/v8/client/TGSExchange.go
@@ -10,7 +10,7 @@ import (
 
 // TGSREQGenerateAndExchange generates the TGS_REQ and performs a TGS exchange to retrieve a ticket to the specified SPN.
 func (cl *Client) TGSREQGenerateAndExchange(spn types.PrincipalName, kdcRealm string, tgt messages.Ticket, sessionKey types.EncryptionKey, renewal bool) (tgsReq messages.TGSReq, tgsRep messages.TGSRep, err error) {
-	tgsReq, err = messages.NewTGSReq(cl.Credentials.CName(), kdcRealm, cl.Config, tgt, sessionKey, spn, renewal)
+	tgsReq, err = messages.NewTGSReq(cl.Credentials.CName(), cl.Credentials.Domain(), kdcRealm, cl.Config, tgt, sessionKey, spn, renewal)
 	if err != nil {
 		return tgsReq, tgsRep, krberror.Errorf(err, krberror.KRBMsgError, "TGS Exchange Error: failed to generate a new TGS_REQ")
 	}
@@ -60,7 +60,7 @@ func (cl *Client) TGSExchange(tgsReq messages.TGSReq, kdcRealm string, tgt messa
 				return tgsReq, tgsRep, err
 			}
 		}
-		tgsReq, err = messages.NewTGSReq(cl.Credentials.CName(), realm, cl.Config, tgsRep.Ticket, tgsRep.DecryptedEncPart.Key, tgsReq.ReqBody.SName, tgsReq.Renewal)
+		tgsReq, err = messages.NewTGSReq(cl.Credentials.CName(), cl.Credentials.Domain(), realm, cl.Config, tgsRep.Ticket, tgsRep.DecryptedEncPart.Key, tgsReq.ReqBody.SName, tgsReq.Renewal)
 		if err != nil {
 			return tgsReq, tgsRep, err
 		}

--- a/v8/test/testdata/test_vectors.go
+++ b/v8/test/testdata/test_vectors.go
@@ -127,6 +127,7 @@ const (
 	KDC_PORT_TEST_GOKRB5                     = "88"
 	KDC_PORT_TEST_GOKRB5_LASTEST             = "98"
 	KDC_PORT_TEST_GOKRB5_RESDOM              = "188"
+	KDC_PORT_TEST_GOKRB5_SUB                 = "288"
 	KDC_PORT_TEST_GOKRB5_OLD                 = "78"
 	KDC_PORT_TEST_GOKRB5_SHORTTICKETS        = "58"
 
@@ -153,6 +154,11 @@ const (
   admin_server = 127.0.0.1:749
   default_domain = test.gokrb5
  }
+ SUB.TEST.GOKRB5 = {
+  kdc = 127.0.0.1:288
+  admin_server = 127.0.0.1:749
+  default_domain = sub.test.gokrb5
+ }
  RESDOM.GOKRB5 = {
   kdc = 10.80.88.88:188
   admin_server = 127.0.0.1:749
@@ -162,6 +168,8 @@ const (
 [domain_realm]
  .test.gokrb5 = TEST.GOKRB5
  test.gokrb5 = TEST.GOKRB5
+ .sub.test.gokrb5 = SUB.TEST.GOKRB5
+ sub.test.gokrb5 = SUB.TEST.GOKRB5
  .resdom.gokrb5 = RESDOM.GOKRB5
  resdom.gokrb5 = RESDOM.GOKRB5
  `


### PR DESCRIPTION
Fixes #130 

### Description

It slightly modifies the `messages.NewTGSReq` signature in order to use the client's realm as the `paRealm` for `TGS_REQ` messages, as discussed in #130 and suggested by @momiji and @snqk (added them as co-authors for credit).

### Proof

I have also added a new Go test (which also relies on a few changes added on the testing environment [here](https://github.com/jcmturner/gokrb5-test/pull/1)) that reproduces the issue. So, you can try to run it without and with the other changes present on this pull request in order to verify that they actually fix that issue (test-driven).

### Considerations

First, in order to get this pull request (CI) fully working, it would require approving & merging the `gokrb5-test`'s pull request ([here](https://github.com/jcmturner/gokrb5-test/pull/1)) first, and re-building and publishing the modified / added Docker images later.

Second, as this slightly modifies part of the public API of the library (the `messages` package), it would probably require bumping up its major version to v9 (unfortunately), but I think the fix does worth it.

<br/>
--

Pinging you @jcmturner for visibility, I'm definitely looking forward for some feedback and ideally getting this merged sooner rather than later, cause as the other users involved, we're experiencing the same issue, and we rather prefer to contribute back to this repository than having to maintain our own fork.

Thanks!