### PR TITLE
Github actions: run tests also on go 1.21/1.22

### DIFF
--- a/.github/workflows/testing.yml
+++ b/.github/workflows/testing.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18.x', '1.19.x', '1.20.x' ]
+        go: [ '1.18.x', '1.19.x', '1.20.x', '1.21.x', '1.22.x' ]
     env:
       TEST_KDC_ADDR: 127.0.0.1
       TEST_HTTP_URL: http://cname.test.gokrb5

--- a/.github/workflows/testingv8.yml
+++ b/.github/workflows/testingv8.yml
@@ -14,7 +14,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        go: [ '1.18.x', '1.19.x', '1.20.x' ]
+        go: [ '1.18.x', '1.19.x', '1.20.x', '1.21.x', '1.22.x' ]
     env:
       TEST_KDC_ADDR: 127.0.0.1
       TEST_HTTP_URL: http://cname.test.gokrb5


### PR DESCRIPTION
I noticed that go 1.21 was not tested, so I added both versions.