### PR TITLE
add support of dialer for TCP

### DIFF
--- a/v8/client/client.go
+++ b/v8/client/client.go
@@ -19,6 +19,7 @@ import (
 	"github.com/jcmturner/gokrb5/v8/krberror"
 	"github.com/jcmturner/gokrb5/v8/messages"
 	"github.com/jcmturner/gokrb5/v8/types"
+	"golang.org/x/net/proxy"
 )
 
 // Client side configuration and state.
@@ -28,6 +29,7 @@ type Client struct {
 	settings    *Settings
 	sessions    *sessions
 	cache       *Cache
+	tcpDialer   proxy.Dialer
 }
 
 // NewWithPassword creates a new client from a password credential.
@@ -326,4 +328,8 @@ func (cl *Client) Print(w io.Writer) {
 
 	k, _ := cl.Credentials.Keytab().JSON()
 	fmt.Fprintf(w, "Keytab:\n%s\n", k)
+}
+
+func (cl *Client) SetDialerForTCP(dialer proxy.Dialer) {
+	cl.tcpDialer = dialer
 }

--- a/v8/client/passwd.go
+++ b/v8/client/passwd.go
@@ -65,7 +65,7 @@ func (cl *Client) sendToKPasswd(msg kadmin.Request) (r kadmin.Reply, err error) 
 			return
 		}
 	} else {
-		rb, err = dialSendTCP(kps, b)
+		rb, err = dialSendTCP(kps, b, cl.tcpDialer)
 		if err != nil {
 			return
 		}

--- a/v8/go.mod
+++ b/v8/go.mod
@@ -12,5 +12,5 @@ require (
 	github.com/jcmturner/rpc/v2 v2.0.3
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.6.0
-	golang.org/x/net v0.7.0 // indirect
+	golang.org/x/net v0.7.0
 )


### PR DESCRIPTION
We have a following setup of our customer:
- Kafka cluster behind proxy;
- Kerberos KDC also behind proxy.

We use Sarama Kafka client https://github.com/IBM/sarama. It uses this library for Kerberos.
Sarama allows setting a dialer, we want to use it also for Kerberos authentication.

We use a TCP proxy, so changes are only relevant for TCP. This is tested and confirmed to work.
UDP proxy support can be added separately (we cannot test it with our systems, so I cannot add it here).