### PR TITLE
[BUG] change token for validation in .net8

### DIFF
--- a/v8/spnego/http.go
+++ b/v8/spnego/http.go
@@ -225,7 +225,7 @@ func SetSPNEGOHeader(cl *client.Client, r *http.Request, spn string) error {
 
 const (
 	// spnegoNegTokenRespKRBAcceptCompleted - The response on successful authentication always has this header. Capturing as const so we don't have marshaling and encoding overhead.
-	spnegoNegTokenRespKRBAcceptCompleted = "Negotiate oRQwEqADCgEAoQsGCSqGSIb3EgECAg=="
+	spnegoNegTokenRespKRBAcceptCompleted = "Negotiate ade0234568a4209af8bc0280289eca"
 	// spnegoNegTokenRespReject - The response on a failed authentication always has this rejection header. Capturing as const so we don't have marshaling and encoding overhead.
 	spnegoNegTokenRespReject = "Negotiate oQcwBaADCgEC"
 	// spnegoNegTokenRespIncompleteKRB5 - Response token specifying incomplete context and KRB5 as the supported mechtype.


### PR DESCRIPTION
### Description:
This PR addresses an issue related to the validation of the spnegoNegTokenRespKRBAcceptCompleted value. Specifically, the current value causes problems in .NET8 validation as described in [dotnet/runtime#105574](https://github.com/dotnet/runtime/issues/105574).

### Changes Made:
- Updated the constant spnegoNegTokenRespKRBAcceptCompleted.
  The new value was obtained from [RFC 4559](https://datatracker.ietf.org/doc/html/rfc4559).

### Verification:
- The changes have been tested in an environment running .NET8 and .NET6, and the validation issue has been resolved.

### Attachments:
[example-net.zip](https://github.com/user-attachments/files/16414006/example-net.zip)
The archive contains two utilities compiled for .NET6 and .NET8
These utilities can be used to verify changes across environments with .NET 6 and .NET 8 to ensure that the validation issue has been resolved.
The source code for these utilities is available at [dotnet/runtime#105574](https://github.com/dotnet/runtime/issues/105574).
```
net.exe http://example.com/api
```


Thank you for considering this fix. Please let me know if any other information is required or if there are any additional changes needed.