### PR TITLE
fix: spnego client reqs forever incrementing

### DIFF
--- a/spnego/http.go
+++ b/spnego/http.go
@@ -112,6 +112,8 @@ func (c *Client) Do(req *http.Request) (resp *http.Response, err error) {
 		}
 		return c.Do(req)
 	}
+	// Clear the saved requests as we have successfully authenticated
+	c.reqs = c.reqs[:0]
 	return resp, err
 }
 


### PR DESCRIPTION
## Background:
Currently, spnego Client maintains a list of redirect requests in a slice of `reqs` that is only incrementing and never cleared, in Client.Do() function, if reqs > 10, it  `return resp, errors.New("stopped after 10 redirects")`.

## Problem:
This will lead to a consequence that the client will always fail to handle redirect after it has accumutively handled more than 10 redirects since its instantiation.

## Solution:
Clears this reqs list when a request has received a response that is neither a redirect, nor unauthorized response that requires negotiation.