### PR TITLE
feat: Add SASL security layer support for GSSAPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@ gokrb5 may work with other versions of Go but they are not formally tested.
 It has been reported that gokrb5 also works with the [gollvm](https://go.googlesource.com/gollvm/) compiler but this is not formally tested.
 
 ## Features
-* **Pure Go** - no dependency on external libraries 
+* **Pure Go** - no dependency on external libraries
 * No platform specific code
 * Server Side
   * HTTP handler wrapper implements SPNEGO Kerberos authentication
@@ -27,6 +27,7 @@ It has been reported that gokrb5 also works with the [gollvm](https://go.googles
 * Client Side
   * Client that can authenticate to an SPNEGO Kerberos authenticated web service
   * Ability to change client's password
+  * SASL security layer support (integrity and confidentiality) for GSSAPI
 * General
   * Kerberos libraries for custom integration
   * Parsing Keytab files
@@ -63,7 +64,9 @@ If you are interested in contributing to gokrb5, great! Please read the [contrib
 * [RFC 3962 Advanced Encryption Standard (AES) Encryption for Kerberos 5](https://tools.ietf.org/html/rfc3962)
 * [RFC 4121 The Kerberos Version 5 GSS-API Mechanism](https://tools.ietf.org/html/rfc4121)
 * [RFC 4178 The Simple and Protected Generic Security Service Application Program Interface (GSS-API) Negotiation Mechanism](https://tools.ietf.org/html/rfc4178.html)
+* [RFC 4422 Simple Authentication and Security Layer (SASL)](https://tools.ietf.org/html/rfc4422)
 * [RFC 4559 SPNEGO-based Kerberos and NTLM HTTP Authentication in Microsoft Windows](https://tools.ietf.org/html/rfc4559.html)
+* [RFC 4752 The Kerberos V5 ("GSSAPI") SASL Mechanism](https://tools.ietf.org/html/rfc4752)
 * [RFC 4757 The RC4-HMAC Kerberos Encryption Types Used by Microsoft Windows](https://tools.ietf.org/html/rfc4757)
 * [RFC 6806 Kerberos Principal Name Canonicalization and Cross-Realm Referrals](https://tools.ietf.org/html/rfc6806.html)
 * [RFC 6113 A Generalized Framework for Kerberos Pre-Authentication](https://tools.ietf.org/html/rfc6113.html)

--- a/v8/README.md
+++ b/v8/README.md
@@ -19,7 +19,7 @@ gokrb5 may work with other versions of Go but they are not formally tested.
 It has been reported that gokrb5 also works with the [gollvm](https://go.googlesource.com/gollvm/) compiler but this is not formally tested.
 
 ## Features
-* **Pure Go** - no dependency on external libraries 
+* **Pure Go** - no dependency on external libraries
 * No platform specific code
 * Server Side
   * HTTP handler wrapper implements SPNEGO Kerberos authentication
@@ -27,6 +27,7 @@ It has been reported that gokrb5 also works with the [gollvm](https://go.googles
 * Client Side
   * Client that can authenticate to an SPNEGO Kerberos authenticated web service
   * Ability to change client's password
+  * SASL security layer support (integrity and confidentiality) for GSSAPI
 * General
   * Kerberos libraries for custom integration
   * Parsing Keytab files
@@ -63,7 +64,9 @@ If you are interested in contributing to gokrb5, great! Please read the [contrib
 * [RFC 3962 Advanced Encryption Standard (AES) Encryption for Kerberos 5](https://tools.ietf.org/html/rfc3962)
 * [RFC 4121 The Kerberos Version 5 GSS-API Mechanism](https://tools.ietf.org/html/rfc4121)
 * [RFC 4178 The Simple and Protected Generic Security Service Application Program Interface (GSS-API) Negotiation Mechanism](https://tools.ietf.org/html/rfc4178.html)
+* [RFC 4422 Simple Authentication and Security Layer (SASL)](https://tools.ietf.org/html/rfc4422)
 * [RFC 4559 SPNEGO-based Kerberos and NTLM HTTP Authentication in Microsoft Windows](https://tools.ietf.org/html/rfc4559.html)
+* [RFC 4752 The Kerberos V5 ("GSSAPI") SASL Mechanism](https://tools.ietf.org/html/rfc4752)
 * [RFC 4757 The RC4-HMAC Kerberos Encryption Types Used by Microsoft Windows](https://tools.ietf.org/html/rfc4757)
 * [RFC 6806 Kerberos Principal Name Canonicalization and Cross-Realm Referrals](https://tools.ietf.org/html/rfc6806.html)
 * [RFC 6113 A Generalized Framework for Kerberos Pre-Authentication](https://tools.ietf.org/html/rfc6113.html)

--- a/v8/USAGE.md
+++ b/v8/USAGE.md
@@ -1,9 +1,9 @@
 ## Version 8 Usage
 
 ### Configuration
-The gokrb5 libraries use the same krb5.conf configuration file format as MIT Kerberos, 
+The gokrb5 libraries use the same krb5.conf configuration file format as MIT Kerberos,
 described [here](https://web.mit.edu/kerberos/krb5-latest/doc/admin/conf_files/krb5_conf.html).
-Config instances can be created by loading from a file path or by passing a string, io.Reader or bufio.Scanner to the 
+Config instances can be created by loading from a file path or by passing a string, io.Reader or bufio.Scanner to the
 relevant method:
 ```go
 import "github.com/jcmturner/gokrb5/v8/config"
@@ -12,13 +12,13 @@ cfg, err := config.NewFromString(krb5Str) //String must have appropriate newline
 cfg, err := config.NewFromReader(reader)
 cfg, err := config.NewFromScanner(scanner)
 ```
+
 ### Keytab files
 Standard keytab files can be read from a file or from a slice of bytes:
 ```go
-import 	"github.com/jcmturner/gokrb5/v8/keytab"
+import "github.com/jcmturner/gokrb5/v8/keytab"
 ktFromFile, err := keytab.Load("/path/to/file.keytab")
 ktFromBytes, err := keytab.Parse(b)
-
 ```
 
 ---
@@ -27,7 +27,7 @@ ktFromBytes, err := keytab.Parse(b)
 **Create** a client instance with either a password or a keytab.
 A configuration must also be passed. Additionally optional additional settings can be provided.
 ```go
-import 	"github.com/jcmturner/gokrb5/v8/client"
+import  "github.com/jcmturner/gokrb5/v8/client"
 cl := client.NewWithPassword("username", "REALM.COM", "password", cfg)
 cl := client.NewWithKeytab("username", "REALM.COM", kt, cfg)
 ```
@@ -57,10 +57,10 @@ cl := client.NewWithPassword("username", "REALM.COM", "password", cfg, client.Di
 #### Authenticate to a Service
 
 ##### HTTP SPNEGO
-Create the HTTP request object and then create an SPNEGO client and use this to process the request with methods that 
+Create the HTTP request object and then create an SPNEGO client and use this to process the request with methods that
 are the same as on a HTTP client.
 If nil is passed as the HTTP client when creating the SPNEGO client the http.DefaultClient is used.
-When creating the SPNEGO client pass the Service Principal Name (SPN) or auto generate the SPN from the request 
+When creating the SPNEGO client pass the Service Principal Name (SPN) or auto generate the SPN from the request
 object by passing a null string "".
 ```go
 r, _ := http.NewRequest("GET", "http://host.test.gokrb5/index.html", nil)
@@ -69,20 +69,20 @@ resp, err := spnegoCl.Do(r)
 ```
 
 ##### Generic Kerberos Client
-To authenticate to a service a client will need to request a service ticket for a Service Principal Name (SPN) and form 
-into an AP_REQ message along with an authenticator encrypted with the session key that was delivered from the KDC along 
+To authenticate to a service a client will need to request a service ticket for a Service Principal Name (SPN) and form
+into an AP_REQ message along with an authenticator encrypted with the session key that was delivered from the KDC along
 with the service ticket.
 
 The steps below outline how to do this.
 * Get the service ticket and session key for the service the client is authenticating to.
-The following method will use the client's cache either returning a valid cached ticket, renewing a cached ticket with 
+The following method will use the client's cache either returning a valid cached ticket, renewing a cached ticket with
 the KDC or requesting a new ticket from the KDC.
 Therefore the GetServiceTicket method can be continually used for the most efficient interaction with the KDC.
 ```go
 tkt, key, err := cl.GetServiceTicket("HTTP/host.test.gokrb5")
 ```
 
-The steps after this will be specific to the application protocol but it will likely involve a client/server 
+The steps after this will be specific to the application protocol but it will likely involve a client/server
 Authentication Protocol exchange (AP exchange).
 This will involve these steps:
 
@@ -96,9 +96,9 @@ auth.GenerateSeqNumberAndSubKey(key.KeyType, etype.GetKeyByteSize())
 The checksum is an application specific value. Set as follows:
 ```go
 auth.Cksum = types.Checksum{
-		CksumType: checksumIDint,
-		Checksum:  checksumBytesSlice,
-	}
+	CksumType: checksumIDint,
+	Checksum:  checksumBytesSlice,
+}
 ```
 * Create the AP_REQ:
 ```go
@@ -108,7 +108,7 @@ APReq, err := messages.NewAPReq(tkt, key, auth)
 Now send the AP_REQ to the service. How this is done will be specific to the application use case.
 
 #### Changing a Client Password
-This feature uses the Microsoft Kerberos Password Change protocol (RFC 3244). 
+This feature uses the Microsoft Kerberos Password Change protocol (RFC 3244).
 This is implemented in Microsoft Active Directory and in MIT krb5kdc as of version 1.7.
 Typically the kpasswd server listens on port 464.
 
@@ -134,16 +134,16 @@ if !ok {
 }
 ```
 
-The client kerberos config (krb5.conf) will need to have either the kpassd_server or admin_server defined in the 
+The client kerberos config (krb5.conf) will need to have either the kpassd_server or admin_server defined in the
 relevant [realms] section. For example:
 ```
 REALM.COM = {
   kdc = 127.0.0.1:88
   kpasswd_server = 127.0.0.1:464
   default_domain = realm.com
- }
+}
 ```
-See https://web.mit.edu/kerberos/krb5-latest/doc/admin/conf_files/krb5_conf.html#realms for more information.
+See <https://web.mit.edu/kerberos/krb5-latest/doc/admin/conf_files/krb5_conf.html#realms> for more information.
 
 #### Client Diagnostics
 In the event of issues the configuration of a client can be investigated with its ``Diagnostics`` method.
@@ -171,18 +171,18 @@ Configure the HTTP handler:
 ```go
 http.Handler("/", spnego.SPNEGOKRB5Authenticate(h, &kt, service.Logger(l)))
 ```
-The handler to be wrapped and the keytab are required arguments. 
+The handler to be wrapped and the keytab are required arguments.
 Additional optional settings can be provided, such as the logger shown above.
 
-Another example of optional settings may be that when using Active Directory where the SPN is mapped to a user account 
-the keytab may contain an entry for this user account. In this case this should be specified as below with the 
+Another example of optional settings may be that when using Active Directory where the SPN is mapped to a user account
+the keytab may contain an entry for this user account. In this case this should be specified as below with the
 ``KeytabPrincipal``:
 ```go
 http.Handler("/", spnego.SPNEGOKRB5Authenticate(h, &kt, service.Logger(l), service.KeytabPrincipal(pn)))
 ```
 
 ##### Session Management
-For efficiency reasons it is not desirable to authenticate on every call to a web service. 
+For efficiency reasons it is not desirable to authenticate on every call to a web service.
 Therefore most authenticated web applications implement some form of session with the user.
 Such sessions can be supported by passing a "session manager" into the ``SPNEGOKRB5Authenticate`` wrapper handler.
 In order to not demand a specific session manager solution, the session manager must implement a simple interface:
@@ -192,11 +192,11 @@ type SessionMgr interface {
 	Get(r *http.Request, k string) ([]byte, error)
 }
 ```
-- New - creates a new session for the request and adds a piece of data (key/value pair) to the session
-- Get - extract from an existing session the value held within it under the key provided. 
+* New - creates a new session for the request and adds a piece of data (key/value pair) to the session
+* Get - extract from an existing session the value held within it under the key provided.
 This should return nil bytes or an error if there is no existing session.
 
-The session manager (sm) that implements this interface should then be passed to the ``SPNEGOKRB5Authenticate`` wrapper 
+The session manager (sm) that implements this interface should then be passed to the ``SPNEGOKRB5Authenticate`` wrapper
 handler as below:
 ```go
 http.Handler("/", spnego.SPNEGOKRB5Authenticate(h, &kt, service.Logger(l), service.SessionManager(sm)))
@@ -207,8 +207,8 @@ The ``httpServer.go`` source file in the examples directory shows how this can b
 ##### Validating Users and Accessing Users' Details
 If authentication succeeds then the request's context will have a credentials objected added to it.
 This object implements the ``github.com/jcmturner/goidentity/identity`` interface.
-If Microsoft Active Directory is used as the KDC then additional ADCredentials are available in the 
-``credentials.Attributes`` map under the key ``credentials.AttributeKeyADCredentials``. 
+If Microsoft Active Directory is used as the KDC then additional ADCredentials are available in the
+``credentials.Attributes`` map under the key ``credentials.AttributeKeyADCredentials``.
 For example the SIDs of the users group membership are available and can be used by your application for authorization.
 
 Checking and access the credentials within your application:
@@ -217,17 +217,17 @@ Checking and access the credentials within your application:
 creds := goidentity.FromHTTPRequestContext(r)
 // Check if it indicates it is authenticated
 if creds != nil && creds.Authenticated() {
-    // Check for Active Directory attributes
+	// Check for Active Directory attributes
 	if ADCredsJSON, ok := creds.Attributes()[credentials.AttributeKeyADCredentials]; ok {
 		ADCreds := new(credentials.ADCredentials)
-        // Unmarshal the AD attributes
+		// Unmarshal the AD attributes
 		err := json.Unmarshal([]byte(ADCredsJSON), ADCreds)
 		if err == nil {
 			// Now access the fields of the ADCredentials struct. For example: ADCreds.GroupMembershipSIDs
 		}
 	}
 } else {
-    // Not authenticated user
+	// Not authenticated user
 	w.WriteHeader(http.StatusUnauthorized)
 	fmt.Fprint(w, "Authentication failed")
 }
@@ -236,10 +236,131 @@ if creds != nil && creds.Authenticated() {
 #### Generic Kerberised Service - Validating Client Details
 To validate the AP_REQ sent by the client on the service side call this method:
 ```go
-import 	"github.com/jcmturner/gokrb5/v8/service"
+import  "github.com/jcmturner/gokrb5/v8/service"
 s := service.NewSettings(&kt) // kt is a keytab and optional settings can also be provided.
 if ok, creds, err := service.VerifyAPREQ(&APReq, s); ok {
-        // Perform application specific actions
-        // creds object has details about the client identity
+	// Perform application specific actions
+	// creds object has details about the client identity
 }
 ```
+
+---
+
+### SASL Security Layers
+
+SASL (Simple Authentication and Security Layer) provides message protection for GSSAPI/Kerberos authentication.
+After authentication, messages can be wrapped with integrity protection (checksums) or confidentiality (encryption).
+
+This is required by many protocols (LDAP, IMAP, SMTP, Kafka) and can be used for Windows Active Directory
+authentication on non-TLS connections.
+
+> **⚠️ Active Directory Warning**: Microsoft Active Directory (per MS-ADTS specification) prohibits using SASL
+> security layers (integrity/confidentiality) over TLS/SSL connections and will reject such connections. When
+> connecting to Active Directory, use SASL security layers only on non-TLS connections (typically port 389).
+>
+> If you use `NewSecureConn()` with a TLS connection and an integrity/confidentiality layer, a warning will be
+> logged to stderr by default. For non-AD LDAP servers that accept this configuration per RFC 4513, you can
+> suppress the warning by setting `GOKRB5_SASL_TLS_NO_WARN=1`.
+
+#### Security Layers
+
+Three security layers are supported:
+
+```go
+import "github.com/jcmturner/gokrb5/v8/gssapi"
+
+const (
+  SecurityLayerNone           SecurityLayer = 1 // Authentication only
+  SecurityLayerIntegrity      SecurityLayer = 2 // HMAC checksums
+  SecurityLayerConfidentiality SecurityLayer = 4 // Encryption + integrity
+)
+```
+
+#### SecurityLayerSession
+
+Create a session to manage message wrapping/unwrapping:
+
+```go
+// Create session with negotiated security layer
+session, err := gssapi.NewSecurityLayerSession(
+	sessionKey,                      // types.EncryptionKey from Kerberos context
+	gssapi.SecurityLayerIntegrity,   // or SecurityLayerConfidentiality
+	true,                            // isInitiator (client=true, server=false)
+	65536,                           // maxMessageSize (0 = unlimited)
+)
+if err != nil {
+	return err
+}
+
+// Wrap a message
+message := []byte("Hello, server!")
+wrapped, err := session.Wrap(message)
+
+// Unwrap on receiving side
+unwrapped, err := session.Unwrap(wrapped)
+```
+
+The session automatically manages:
+
+* Sequence numbers (thread-safe)
+* GSS-API token format (RFC 4121)
+* Token rotation (RRC) for Windows AD compatibility
+
+#### SASL Framing
+
+For protocols that use SASL framing (4-byte length prefix):
+
+```go
+// Wrap with SASL framing
+framedMessage, err := session.WrapWithSASLFraming(message)
+
+// Send over network
+conn.Write(framedMessage)
+
+// On receiving side, read and unwrap
+data := make([]byte, 8192)
+n, err := conn.Read(data)
+unwrapped, err := session.UnwrapFromSASLFraming(data[:n])
+```
+
+#### SecureConn - Transparent Wrapper
+
+For automatic message protection, wrap your connection:
+
+```go
+// After authentication and security layer negotiation
+secureConn := gssapi.NewSecureConn(conn, session)
+
+// All Read/Write operations are now transparently protected
+secureConn.Write([]byte("Hello"))  // Automatically wrapped
+buf := make([]byte, 1024)
+n, err := secureConn.Read(buf)     // Automatically unwrapped
+```
+
+This provides a drop-in replacement for `net.Conn` with transparent SASL protection.
+
+#### Protocol Integration Example
+
+Typical protocol integration flow:
+
+```go
+// 1. Perform GSSAPI authentication (protocol-specific)
+// 2. Negotiate security layer with server (protocol-specific)
+// 3. Extract session key from Kerberos context
+sessionKey := kerberosContext.Key()
+
+// 4. Create security layer session
+session, err := gssapi.NewSecurityLayerSession(
+	sessionKey,
+	negotiatedLayer,  // From protocol negotiation
+	true,             // Client side
+	maxMsgSize,       // From negotiation
+)
+
+// 5. Wrap the connection for transparent protection
+conn = gssapi.NewSecureConn(conn, session)
+
+// 6. All subsequent protocol operations are automatically protected
+```
+
+See `examples/example-sasl.go` for complete working examples including LDAP-style integration.

--- a/v8/examples/example-sasl.go
+++ b/v8/examples/example-sasl.go
@@ -1,0 +1,266 @@
+//go:build examples
+// +build examples
+
+package main
+
+import (
+	"encoding/hex"
+	"fmt"
+	"log"
+	"net"
+	"os"
+
+	"github.com/jcmturner/gokrb5/v8/client"
+	"github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/gssapi"
+	"github.com/jcmturner/gokrb5/v8/keytab"
+	"github.com/jcmturner/gokrb5/v8/test/testdata"
+)
+
+// This example demonstrates two scenarios for using SASL security layers with gokrb5:
+// 1. Simple generic usage with basic Wrap/Unwrap and SASL framing
+// 2. LDAP-style usage with security layer negotiation and SecureConn wrapper
+//
+// === GSS-API WrapToken Structure (RFC 4121) ===
+// Byte 0-1:   Token ID (0x05 0x04)
+// Byte 2:     Flags (acceptor, sealed, subkey)
+// Byte 3:     Filler (0xFF)
+// Byte 4-5:   EC (Extra Count) - meaning depends on sealed flag:
+//             - Integrity tokens: EC = checksum size
+//             - Confidentiality tokens: EC = filler size (usually 0)
+// Byte 6-7:   RRC (Right Rotation Count)
+//             - Windows AD commonly uses RRC for optimization
+//             - Rotation: last RRC bytes moved to front after header
+//             - Example: RRC=28 moves last 28 bytes to front
+// Byte 8-15:  Sequence number (64-bit, prevents replay attacks)
+// Byte 16+:   Payload (encrypted for confidentiality, plaintext for integrity)
+// Byte N+:    Checksum (HMAC, only for integrity tokens)
+//
+// === SASL Framing (RFC 4422) ===
+// Byte 0-3:   Length (big-endian, 32-bit, network byte order)
+// Byte 4+:    Complete GSS-API WrapToken
+//
+// === Key Usage Values (RFC 4121) ===
+// GSSAPI_ACCEPTOR_SEAL (22):  Server → Client messages
+// GSSAPI_INITIATOR_SEAL (24): Client → Server messages
+//
+// === Security Features ===
+// - Integrity: HMAC checksums (AES128/256-HMAC-SHA1-96)
+// - Confidentiality: AES encryption with embedded integrity
+// - Replay protection: Sequence number validation
+// - Thread-safe: Mutex-protected sequence management
+// - Windows AD compatible: RRC support tested with AD (Layer 2: RRC=12, Layer 4: RRC=28)
+// - Production tested: LDAP operations on port 389 (no TLS) against Windows AD
+// - Full RFC compliance: RFC 4121, RFC 4752, RFC 4422
+//
+// === Active Directory and TLS ===
+// WARNING: Microsoft Active Directory (per MS-ADTS) prohibits using SASL security
+// layers (integrity/confidentiality) over TLS connections. AD will reject such
+// connections. This example demonstrates non-TLS usage, which is required for AD.
+//
+// If you use NewSecureConn() with a TLS connection and integrity/confidentiality
+// layer, a warning will be logged to stderr by default. For non-AD LDAP servers
+// that accept this per RFC 4513, suppress with GOKRB5_SASL_TLS_NO_WARN=1.
+
+func main() {
+	l := log.New(os.Stderr, "GOKRB5 SASL Example: ", log.Ldate|log.Ltime|log.Lshortfile)
+	l.Println("=== SASL Security Layer Examples ===")
+
+	// Scenario 1: Simple Generic Usage
+	l.Println("--- Scenario 1: Simple Generic Usage ---")
+	simpleGenericExample(l)
+
+	l.Println("--- Scenario 2: LDAP-Style Usage ---")
+	ldapStyleExample(l)
+}
+
+// simpleGenericExample demonstrates basic Wrap/Unwrap and SASL framing
+func simpleGenericExample(l *log.Logger) {
+	// Setup: Create a Kerberos client and get a session key
+	b, _ := hex.DecodeString(testdata.KEYTAB_TESTUSER1_USER_GOKRB5)
+	kt := keytab.New()
+	kt.Unmarshal(b)
+	c, _ := config.NewFromString(testdata.KRB5_CONF)
+	cl := client.NewWithKeytab("testuser1", "USER.GOKRB5", kt, c, client.DisablePAFXFAST(true), client.Logger(l))
+	err := cl.Login()
+	if err != nil {
+		l.Fatalf("Login failed: %v", err)
+	}
+
+	// Get a service ticket to obtain the session key
+	tkt, sessionKey, err := cl.GetServiceTicket("HTTP/host.test.gokrb5")
+	if err != nil {
+		l.Fatalf("Failed to get service ticket: %v", err)
+	}
+	_ = tkt // Service ticket would be used in AP_REQ
+
+	l.Println("✓ Obtained session key from Kerberos")
+
+	// Create a SecurityLayerSession with Integrity layer (Layer 2)
+	session, err := gssapi.NewSecurityLayerSession(
+		sessionKey,
+		gssapi.SecurityLayerIntegrity, // HMAC checksums
+		true,                          // isInitiator: true for client, false for server
+		65536,                         // maxMessageSize: 64KB limit
+	)
+	if err != nil {
+		l.Fatalf("Failed to create security layer session: %v", err)
+	}
+	l.Println("✓ Created SecurityLayerSession with Integrity layer")
+
+	// Basic Wrap/Unwrap
+	message := []byte("Hello, secure world!")
+	l.Printf("Original message: %s", message)
+
+	// Wrap creates a GSS-API WrapToken (see file header for structure details)
+	wrapped, err := session.Wrap(message)
+	if err != nil {
+		l.Fatalf("Failed to wrap message: %v", err)
+	}
+
+	l.Printf("Wrapped token: %d bytes (header=16, payload=%d, checksum=%d)",
+		len(wrapped), len(message), len(wrapped)-16-len(message))
+
+	// Unwrap verifies token ID, handles RRC rotation, verifies checksum, checks sequence
+	receivedData := wrapped // Simulate network transmission
+	unwrapped, err := session.Unwrap(receivedData)
+	if err != nil {
+		l.Fatalf("Failed to unwrap message: %v", err)
+	}
+
+	l.Printf("Unwrapped message: %s", unwrapped)
+	l.Println("✓ Message integrity verified")
+
+	// SASL Framing - used by protocols like LDAP, IMAP, SMTP
+	// Adds 4-byte length prefix before GSS-API token
+	l.Println("Testing SASL framing...")
+
+	framedMessage, err := session.WrapWithSASLFraming(message)
+	if err != nil {
+		l.Fatalf("Failed to wrap with SASL framing: %v", err)
+	}
+
+	l.Printf("Framed message: %d bytes (prefix=4, token=%d)",
+		len(framedMessage), len(framedMessage)-4)
+
+	receivedFramed := framedMessage // Simulate network transmission
+	unframedMessage, err := session.UnwrapFromSASLFraming(receivedFramed)
+	if err != nil {
+		l.Fatalf("Failed to unwrap from SASL framing: %v", err)
+	}
+
+	l.Printf("Unframed message: %s", unframedMessage)
+	l.Println("✓ SASL framing handled correctly")
+
+	// Note: For confidentiality (encryption), use SecurityLayerConfidentiality (Layer 4)
+}
+
+// ldapStyleExample demonstrates LDAP-style integration with SecureConn
+// Real LDAP scenario:
+// 1. TCP connection to LDAP server (port 389)
+// 2. LDAP Bind with SASL/GSSAPI mechanism
+// 3. Security layer negotiation (server offers layers, client chooses)
+// 4. Wrap connection with SecureConn
+// 5. All LDAP operations transparently protected
+func ldapStyleExample(l *log.Logger) {
+	// Setup: Authenticate with Kerberos
+	b, _ := hex.DecodeString(testdata.KEYTAB_TESTUSER1_USER_GOKRB5)
+	kt := keytab.New()
+	kt.Unmarshal(b)
+	c, _ := config.NewFromString(testdata.KRB5_CONF)
+	cl := client.NewWithKeytab("testuser1", "USER.GOKRB5", kt, c, client.DisablePAFXFAST(true), client.Logger(l))
+	err := cl.Login()
+	if err != nil {
+		l.Fatalf("Login failed: %v", err)
+	}
+
+	_, sessionKey, err := cl.GetServiceTicket("ldap/dc.example.com")
+	if err != nil {
+		l.Fatalf("Failed to get service ticket: %v", err)
+	}
+
+	l.Println("✓ GSSAPI authentication completed")
+
+	// Simulate LDAP security layer negotiation
+	// Real LDAP: server sends supported layers, client responds with chosen layer
+	negotiatedLayer := gssapi.SecurityLayerIntegrity
+	maxMessageSize := 65536
+
+	l.Printf("✓ Negotiated security layer: %d (Integrity)", negotiatedLayer)
+	l.Printf("✓ Max message size: %d bytes", maxMessageSize)
+
+	// Create security layer session
+	session, err := gssapi.NewSecurityLayerSession(
+		sessionKey,
+		negotiatedLayer,
+		true, // Client side
+		maxMessageSize,
+	)
+	if err != nil {
+		l.Fatalf("Failed to create security layer session: %v", err)
+	}
+
+	// Simulate network connection (real: conn, err := net.Dial("tcp", "dc.example.com:389"))
+	// NOTE: For Active Directory, use non-TLS port (389), not LDAPS/TLS port (636)
+	// AD prohibits SASL security layers over TLS per MS-ADTS specification
+	clientConn, serverConn := net.Pipe()
+	defer clientConn.Close()
+	defer serverConn.Close()
+
+	// Wrap connection with SecureConn for transparent SASL protection
+	secureConn := gssapi.NewSecureConn(clientConn, session)
+	l.Println("✓ Connection wrapped with SecureConn")
+
+	// Server side setup (for this simulation)
+	serverSession, _ := gssapi.NewSecurityLayerSession(
+		sessionKey,
+		negotiatedLayer,
+		false, // Server side (isInitiator=false)
+		maxMessageSize,
+	)
+	secureServer := gssapi.NewSecureConn(serverConn, serverSession)
+
+	// Simulate LDAP search request
+	// All Read/Write operations are now automatically wrapped/unwrapped
+	searchRequest := []byte("LDAP Search Request: (objectClass=user)")
+	l.Printf("Client writes: %s", searchRequest)
+
+	// Write is automatically wrapped with SASL framing
+	_, err = secureConn.Write(searchRequest)
+	if err != nil {
+		l.Fatalf("Failed to write: %v", err)
+	}
+	l.Println("✓ Message automatically wrapped and sent")
+
+	// Server reads - automatically unwrapped
+	serverBuf := make([]byte, 4096)
+	n, err := secureServer.Read(serverBuf)
+	if err != nil {
+		l.Fatalf("Server failed to read: %v", err)
+	}
+
+	receivedRequest := serverBuf[:n]
+	l.Printf("Server received: %s", receivedRequest)
+	l.Println("✓ Message automatically unwrapped")
+
+	// Server sends response
+	searchResponse := []byte("LDAP Search Response: 42 entries found")
+	l.Printf("Server writes: %s", searchResponse)
+
+	_, err = secureServer.Write(searchResponse)
+	if err != nil {
+		l.Fatalf("Server failed to write: %v", err)
+	}
+
+	// Client receives response - automatically unwrapped
+	clientBuf := make([]byte, 4096)
+	n, err = secureConn.Read(clientBuf)
+	if err != nil {
+		l.Fatalf("Client failed to read: %v", err)
+	}
+
+	receivedResponse := clientBuf[:n]
+	l.Printf("Client received: %s", receivedResponse)
+	l.Println("✓ Response automatically unwrapped")
+	l.Println("✓ Bidirectional communication successful")
+}

--- a/v8/gssapi/securitylayer.go
+++ b/v8/gssapi/securitylayer.go
@@ -86,8 +86,17 @@ func NewSecurityLayerSession(key types.EncryptionKey, layer SecurityLayer, isIni
 // Wrap wraps a message according to the negotiated security layer.
 // For SecurityLayerNone, it returns the message unchanged.
 // For SecurityLayerIntegrity, it adds a checksum.
-// For SecurityLayerConfidentiality, it encrypts and adds a checksum.
+// For SecurityLayerConfidentiality, it encrypts and adds integrity protection.
 // The returned bytes include the GSS-API WrapToken format (RFC 4121).
+//
+// Encryption Model (two layers):
+// 1. GSS-API layer (RFC 4121): Creates (message | filler | embedded-header)
+// 2. Kerberos crypto layer (RFC 3961): Adds (confounder | data | padding)
+//
+// Final encrypted structure: Encrypt(confounder | message | filler | embedded-header) | HMAC
+//
+// The filler bytes ensure no padding is added after the embedded header, satisfying
+// RFC 4121 section 4.2.4: "there SHALL be no crypto-system residue present after decryption."
 func (s *SecurityLayerSession) Wrap(message []byte) ([]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -110,26 +119,28 @@ func (s *SecurityLayerSession) Wrap(message []byte) ([]byte, error) {
 		flags |= 0x02 // Set sealed (encrypted) flag
 	}
 
-	// Build the header that will be used for encryption or checksum
-	// For now, RRC is 0 in the embedded header (will be set in outer header if needed)
-	headerForCrypto := make([]byte, 16)
-	copy(headerForCrypto[0:2], []byte{0x05, 0x04})
-	headerForCrypto[2] = flags
-	headerForCrypto[3] = 0xFF
-	// EC and RRC are 0 in the embedded header
-	binary.BigEndian.PutUint64(headerForCrypto[8:16], s.sendSeqNum)
-
-	var payload []byte
-	var ec uint16
+	// Create wrap token early with flags and sequence number
+	// EC and Payload will be set after determining encryption/integrity details
+	token := &WrapToken{
+		Flags:     flags,
+		EC:        0, // Set after determining payload
+		RRC:       0,
+		SndSeqNum: s.sendSeqNum,
+	}
 
 	if s.layer == SecurityLayerConfidentiality {
 		debugLog("WRAP: Creating confidentiality token")
-		// RFC 4121 4.2.4: Encrypt(plaintext | filler | header)
-		// For now, use 0 filler bytes
-		fillerSize := 0
+		// RFC 4121 section 4.2.4: Encrypt(plaintext | filler | embedded-header)
+		// Build the embedded header with EC=0 and RRC=0
+		headerForCrypto := token.GetEmbeddedHeader()
+
+		// Calculate filler size to eliminate crypto-system residue per RFC 4121 section 4.2.4.
+		// This prevents RFC 3961's EncryptMessage from adding zero-padding after the embedded header.
+		fillerSize := s.calculateFillerSize(len(message))
 		toEncrypt := make([]byte, len(message)+fillerSize+16)
 		copy(toEncrypt, message)
-		// filler would go here (all zeros if needed)
+		// Filler bytes (if any) are already zero-initialized in the slice
+		// They go between the message and the embedded header
 		copy(toEncrypt[len(message)+fillerSize:], headerForCrypto)
 
 		debugLog("WRAP: Encrypting %d bytes (message=%d + filler=%d + header=16)",
@@ -141,24 +152,15 @@ func (s *SecurityLayerSession) Wrap(message []byte) ([]byte, error) {
 			debugLog("WRAP: Encryption FAILED: %v", err)
 			return nil, fmt.Errorf("failed to encrypt payload: %w", err)
 		}
-		payload = encryptedPayload
-		ec = uint16(fillerSize) // EC = filler size for confidentiality tokens
-		debugLog("WRAP: Encrypted payload length=%d, EC=%d (filler size)", len(payload), ec)
+		token.Payload = encryptedPayload
+		token.EC = uint16(fillerSize) // EC = filler size for confidentiality tokens
+		debugLog("WRAP: Encrypted payload length=%d, EC=%d (filler size)", len(token.Payload), token.EC)
 	} else {
 		debugLog("WRAP: Creating integrity token")
 		// For integrity-only, payload is plaintext
-		payload = message
-		ec = uint16(s.encType.GetHMACBitLength() / 8) // EC = checksum size for integrity tokens
-		debugLog("WRAP: Using plaintext payload, EC=%d (checksum size)", ec)
-	}
-
-	// Create wrap token with proper EC value
-	token := &WrapToken{
-		Flags:     flags,
-		EC:        ec,
-		RRC:       0,
-		SndSeqNum: s.sendSeqNum,
-		Payload:   payload,
+		token.Payload = message
+		token.EC = uint16(s.encType.GetHMACBitLength() / 8) // EC = checksum size for integrity tokens
+		debugLog("WRAP: Using plaintext payload, EC=%d (checksum size)", token.EC)
 	}
 
 	debugLog("WRAP: Token created - Flags=%#02x, EC=%d, RRC=%d, SeqNum=%d, PayloadLen=%d",
@@ -198,8 +200,17 @@ func (s *SecurityLayerSession) Wrap(message []byte) ([]byte, error) {
 
 // Unwrap unwraps a GSS-API wrapped message.
 // For SecurityLayerNone, it returns the message unchanged.
-// For SecurityLayerIntegrity and SecurityLayerConfidentiality, it verifies the checksum
+// For SecurityLayerIntegrity and SecurityLayerConfidentiality, it verifies integrity
 // and decrypts if necessary.
+//
+// Decryption process (two layers):
+// 1. Kerberos crypto layer (RFC 3961): DecryptMessage removes confounder
+//    Returns: message | filler | embedded-header (with no padding due to filler)
+// 2. GSS-API layer (RFC 4121): Strips EC (filler size) + 16 (header) bytes
+//    Returns: clean message
+//
+// The EC field in confidentiality tokens indicates the filler size, allowing us to
+// extract the original message without any crypto-system residue.
 func (s *SecurityLayerSession) Unwrap(wrappedMessage []byte) ([]byte, error) {
 	s.mu.Lock()
 	defer s.mu.Unlock()
@@ -352,6 +363,63 @@ func (s *SecurityLayerSession) getKeyUsage(sending bool) uint32 {
 		return keyusage.GSSAPI_ACCEPTOR_SEAL
 	}
 	return keyusage.GSSAPI_INITIATOR_SEAL
+}
+
+// calculateFillerSize computes the number of filler bytes needed per RFC 4121 section 4.2.4
+// to eliminate crypto-system residue after decryption.
+//
+// RFC 4121 states: "The values and size of the filler octets are chosen by implementations,
+// such that there SHALL be no crypto-system residue present after the decryption."
+//
+// The encryption happens in two layers:
+// 1. GSS-API (RFC 4121): Encrypts (message | filler | embedded-header)
+// 2. Kerberos Crypto (RFC 3961): Adds confounder and may add zero-padding
+//
+// RFC 3961's EncryptMessage adds:
+//   - Confounder at the beginning (typically 8 or 16 bytes)
+//   - Zero-padding at the end to align to cipher block size
+//
+// The zero-padding added by RFC 3961 is NOT removed during decryption, so it becomes
+// "crypto-system residue" that RFC 4121 requires us to eliminate. We do this by adding
+// filler bytes BEFORE the embedded header so that the total length is already aligned,
+// preventing RFC 3961 from adding any padding after the embedded header.
+//
+// Returns 0 for encryption types that don't need filler (AES-CTS, RC4).
+func (s *SecurityLayerSession) calculateFillerSize(messageLen int) int {
+	// Get the cipher block size in bytes
+	blockSize := s.encType.GetCypherBlockBitLength() / 8
+
+	// For stream ciphers or block size of 1, no filler needed
+	if blockSize <= 1 {
+		return 0
+	}
+
+	// For CTS (Ciphertext Stealing) modes, indicated by GetMessageBlockByteSize() == 1,
+	// no filler is needed as CTS handles arbitrary lengths without padding
+	if s.encType.GetMessageBlockByteSize() == 1 {
+		return 0
+	}
+
+	// Calculate the total length that will be encrypted by RFC 3961:
+	// confounder + message + filler + embedded-header (16 bytes)
+	confounderSize := s.encType.GetConfounderByteSize()
+	embeddedHeaderSize := 16
+
+	// Current total without filler
+	totalWithoutFiller := confounderSize + messageLen + embeddedHeaderSize
+
+	// If already aligned to block size, no filler needed
+	if totalWithoutFiller%blockSize == 0 {
+		return 0
+	}
+
+	// Calculate filler to align to block size
+	fillerSize := blockSize - (totalWithoutFiller % blockSize)
+
+	debugLog("FILLER: blockSize=%d, confounderSize=%d, messageLen=%d, totalWithoutFiller=%d, fillerSize=%d",
+		blockSize, confounderSize, messageLen, totalWithoutFiller, fillerSize)
+
+	return fillerSize
 }
 
 // WrapWithSASLFraming wraps a message and prepends the 4-byte SASL length header.

--- a/v8/gssapi/securitylayer.go
+++ b/v8/gssapi/securitylayer.go
@@ -1,0 +1,544 @@
+package gssapi
+
+import (
+	"crypto/tls"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"sync"
+	"time"
+
+	"github.com/jcmturner/gokrb5/v8/crypto"
+	"github.com/jcmturner/gokrb5/v8/crypto/etype"
+	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
+	"github.com/jcmturner/gokrb5/v8/types"
+)
+
+// Enable debug logging by setting GOKRB5_DEBUG=1 environment variable
+var debugEnabled = os.Getenv("GOKRB5_DEBUG") == "1"
+
+func debugLog(format string, args ...interface{}) {
+	if debugEnabled {
+		fmt.Printf("[GSSAPI DEBUG] "+format+"\n", args...)
+	}
+}
+
+func min(a, b int) int {
+	if a < b {
+		return a
+	}
+	return b
+}
+
+// SecurityLayer represents the SASL security layer type as defined in RFC 4752.
+type SecurityLayer uint8
+
+const (
+	// SecurityLayerNone indicates no security layer (authentication only).
+	SecurityLayerNone SecurityLayer = 1
+	// SecurityLayerIntegrity indicates integrity protection (checksums).
+	SecurityLayerIntegrity SecurityLayer = 2
+	// SecurityLayerConfidentiality indicates confidentiality and integrity (encryption + checksums).
+	SecurityLayerConfidentiality SecurityLayer = 4
+)
+
+// SecurityLayerSession manages GSS-API message wrapping for SASL security layers.
+// It maintains sequence numbers and session keys for wrapping and unwrapping messages
+// according to RFC 4121 (Kerberos GSS-API v2) and RFC 4752 (GSSAPI SASL mechanism).
+type SecurityLayerSession struct {
+	key            types.EncryptionKey
+	layer          SecurityLayer
+	isInitiator    bool
+	sendSeqNum     uint64
+	recvSeqNum     uint64
+	maxMessageSize int
+	mu             sync.Mutex
+	encType        etype.EType
+}
+
+// NewSecurityLayerSession creates a new security layer session for wrapping/unwrapping messages.
+// The isInitiator parameter should be true for clients and false for servers.
+// The maxMessageSize parameter limits the size of unwrapped messages (0 for unlimited).
+func NewSecurityLayerSession(key types.EncryptionKey, layer SecurityLayer, isInitiator bool, maxMessageSize int) (*SecurityLayerSession, error) {
+	if layer != SecurityLayerNone && layer != SecurityLayerIntegrity && layer != SecurityLayerConfidentiality {
+		return nil, fmt.Errorf("invalid security layer: %d", layer)
+	}
+
+	encType, err := crypto.GetEtype(key.KeyType)
+	if err != nil {
+		return nil, fmt.Errorf("failed to get encryption type: %w", err)
+	}
+
+	return &SecurityLayerSession{
+		key:            key,
+		layer:          layer,
+		isInitiator:    isInitiator,
+		sendSeqNum:     0,
+		recvSeqNum:     0,
+		maxMessageSize: maxMessageSize,
+		encType:        encType,
+	}, nil
+}
+
+// Wrap wraps a message according to the negotiated security layer.
+// For SecurityLayerNone, it returns the message unchanged.
+// For SecurityLayerIntegrity, it adds a checksum.
+// For SecurityLayerConfidentiality, it encrypts and adds a checksum.
+// The returned bytes include the GSS-API WrapToken format (RFC 4121).
+func (s *SecurityLayerSession) Wrap(message []byte) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	debugLog("WRAP: Input message length=%d", len(message))
+	debugLog("WRAP: Input message (first %d bytes hex)=%x", min(len(message), 100), message[:min(len(message), 100)])
+	debugLog("WRAP: Layer=%d, IsInitiator=%v, SeqNum=%d", s.layer, s.isInitiator, s.sendSeqNum)
+
+	if s.layer == SecurityLayerNone {
+		debugLog("WRAP: Layer is None, returning message unchanged")
+		return message, nil
+	}
+
+	// Determine flags based on initiator status and security layer
+	var flags byte
+	if !s.isInitiator {
+		flags |= 0x01 // Set acceptor flag
+	}
+	if s.layer == SecurityLayerConfidentiality {
+		flags |= 0x02 // Set sealed (encrypted) flag
+	}
+
+	// Build the header that will be used for encryption or checksum
+	// For now, RRC is 0 in the embedded header (will be set in outer header if needed)
+	headerForCrypto := make([]byte, 16)
+	copy(headerForCrypto[0:2], []byte{0x05, 0x04})
+	headerForCrypto[2] = flags
+	headerForCrypto[3] = 0xFF
+	// EC and RRC are 0 in the embedded header
+	binary.BigEndian.PutUint64(headerForCrypto[8:16], s.sendSeqNum)
+
+	var payload []byte
+	var ec uint16
+
+	if s.layer == SecurityLayerConfidentiality {
+		debugLog("WRAP: Creating confidentiality token")
+		// RFC 4121 4.2.4: Encrypt(plaintext | filler | header)
+		// For now, use 0 filler bytes
+		fillerSize := 0
+		toEncrypt := make([]byte, len(message)+fillerSize+16)
+		copy(toEncrypt, message)
+		// filler would go here (all zeros if needed)
+		copy(toEncrypt[len(message)+fillerSize:], headerForCrypto)
+
+		debugLog("WRAP: Encrypting %d bytes (message=%d + filler=%d + header=16)",
+			len(toEncrypt), len(message), fillerSize)
+
+		keyUsage := s.getKeyUsage(true)
+		_, encryptedPayload, err := s.encType.EncryptMessage(s.key.KeyValue, toEncrypt, keyUsage)
+		if err != nil {
+			debugLog("WRAP: Encryption FAILED: %v", err)
+			return nil, fmt.Errorf("failed to encrypt payload: %w", err)
+		}
+		payload = encryptedPayload
+		ec = uint16(fillerSize) // EC = filler size for confidentiality tokens
+		debugLog("WRAP: Encrypted payload length=%d, EC=%d (filler size)", len(payload), ec)
+	} else {
+		debugLog("WRAP: Creating integrity token")
+		// For integrity-only, payload is plaintext
+		payload = message
+		ec = uint16(s.encType.GetHMACBitLength() / 8) // EC = checksum size for integrity tokens
+		debugLog("WRAP: Using plaintext payload, EC=%d (checksum size)", ec)
+	}
+
+	// Create wrap token with proper EC value
+	token := &WrapToken{
+		Flags:     flags,
+		EC:        ec,
+		RRC:       0,
+		SndSeqNum: s.sendSeqNum,
+		Payload:   payload,
+	}
+
+	debugLog("WRAP: Token created - Flags=%#02x, EC=%d, RRC=%d, SeqNum=%d, PayloadLen=%d",
+		token.Flags, token.EC, token.RRC, token.SndSeqNum, len(token.Payload))
+
+	// Compute outer checksum only for integrity tokens
+	// For confidentiality tokens, encryption provides integrity (no outer checksum)
+	if s.layer != SecurityLayerConfidentiality {
+		keyUsage := s.getKeyUsage(true)
+		debugLog("WRAP: Computing outer checksum with key usage=%d", keyUsage)
+		if err := token.SetCheckSum(s.key, keyUsage); err != nil {
+			debugLog("WRAP: Checksum computation FAILED: %v", err)
+			return nil, fmt.Errorf("failed to compute checksum: %w", err)
+		}
+		debugLog("WRAP: Checksum computed, length=%d", len(token.CheckSum))
+	} else {
+		debugLog("WRAP: Confidentiality token, no outer checksum needed")
+		token.CheckSum = []byte{} // No outer checksum for confidentiality
+	}
+
+	// Increment sequence number for next message
+	s.sendSeqNum++
+
+	// Marshal token to bytes
+	wrappedBytes, err := token.Marshal()
+	if err != nil {
+		debugLog("WRAP: Marshal FAILED: %v", err)
+		return nil, fmt.Errorf("failed to marshal wrap token: %w", err)
+	}
+
+	debugLog("WRAP: Marshaled token length=%d", len(wrappedBytes))
+	debugLog("WRAP: Marshaled token (first %d bytes hex)=%x", min(len(wrappedBytes), 100), wrappedBytes[:min(len(wrappedBytes), 100)])
+	debugLog("WRAP: SUCCESS")
+
+	return wrappedBytes, nil
+}
+
+// Unwrap unwraps a GSS-API wrapped message.
+// For SecurityLayerNone, it returns the message unchanged.
+// For SecurityLayerIntegrity and SecurityLayerConfidentiality, it verifies the checksum
+// and decrypts if necessary.
+func (s *SecurityLayerSession) Unwrap(wrappedMessage []byte) ([]byte, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	debugLog("UNWRAP: Input wrapped message length=%d", len(wrappedMessage))
+	debugLog("UNWRAP: Input wrapped message (first %d bytes hex)=%x", min(len(wrappedMessage), 100), wrappedMessage[:min(len(wrappedMessage), 100)])
+	debugLog("UNWRAP: Layer=%d, IsInitiator=%v, ExpectedSeqNum>=%d", s.layer, s.isInitiator, s.recvSeqNum)
+
+	if s.layer == SecurityLayerNone {
+		debugLog("UNWRAP: Layer is None, returning message unchanged")
+		return wrappedMessage, nil
+	}
+
+	// Parse the wrap token
+	var token WrapToken
+	expectFromAcceptor := s.isInitiator // If we're initiator, expect from acceptor
+	debugLog("UNWRAP: Parsing WrapToken, expectFromAcceptor=%v", expectFromAcceptor)
+	if err := token.Unmarshal(wrappedMessage, expectFromAcceptor); err != nil {
+		debugLog("UNWRAP: Unmarshal FAILED: %v", err)
+		return nil, fmt.Errorf("failed to unmarshal wrap token: %w", err)
+	}
+
+	debugLog("UNWRAP: Token parsed - Flags=%#02x, EC=%d, RRC=%d, SeqNum=%d, PayloadLen=%d",
+		token.Flags, token.EC, token.RRC, token.SndSeqNum, len(token.Payload))
+	debugLog("UNWRAP: Sealed flag set=%v", (token.Flags&0x02) != 0)
+
+	// Handle RRC (Right Rotation Count) per RFC 4121 section 4.2.6.2
+	// When RRC != 0, the encrypted/wrapped data is rotated right by RRC bytes
+	// We need to un-rotate (rotate left) to restore original order
+	if token.RRC != 0 {
+		debugLog("UNWRAP: RRC=%d, performing un-rotation", token.RRC)
+		rrc := int(token.RRC)
+
+		// Reconstruct the message with proper rotation
+		// The wrappedMessage is: [Header 16 bytes][Rotated Data]
+		// We need to un-rotate everything after the header
+		if len(wrappedMessage) > 16 {
+			header := wrappedMessage[:16]
+			rotatedData := wrappedMessage[16:]
+
+			if rrc > 0 && rrc < len(rotatedData) {
+				// Un-rotate: left rotation by RRC bytes
+				// Move the first RRC bytes to the end
+				unrotated := make([]byte, len(header)+len(rotatedData))
+				copy(unrotated[:16], header)
+				copy(unrotated[16:], rotatedData[rrc:])                      // Rest goes first
+				copy(unrotated[16+len(rotatedData)-rrc:], rotatedData[:rrc]) // First RRC bytes go last
+
+				debugLog("UNWRAP: Un-rotated data length=%d", len(rotatedData))
+
+				// Replace the wrapped message with the un-rotated version
+				wrappedMessage = unrotated
+
+				// Re-parse the un-rotated token
+				token = WrapToken{}
+				if err := token.Unmarshal(unrotated, expectFromAcceptor); err != nil {
+					debugLog("UNWRAP: Re-parse after un-rotation FAILED: %v", err)
+					return nil, fmt.Errorf("failed to unmarshal un-rotated wrap token: %w", err)
+				}
+				debugLog("UNWRAP: After un-rotation - EC=%d, PayloadLen=%d, ChecksumLen=%d",
+					token.EC, len(token.Payload), len(token.CheckSum))
+			} else {
+				debugLog("UNWRAP: WARNING: Invalid RRC value %d for data length %d", rrc, len(rotatedData))
+			}
+		}
+	}
+
+	// Verify sequence number (basic check - could be enhanced with replay detection)
+	if token.SndSeqNum < s.recvSeqNum {
+		debugLog("UNWRAP: Sequence number check FAILED: got %d, expected >= %d", token.SndSeqNum, s.recvSeqNum)
+		return nil, fmt.Errorf("sequence number out of order: got %d, expected >= %d", token.SndSeqNum, s.recvSeqNum)
+	}
+	s.recvSeqNum = token.SndSeqNum + 1
+	debugLog("UNWRAP: Sequence number OK, updated recvSeqNum to %d", s.recvSeqNum)
+
+	// RFC 4121: For confidentiality tokens, the encryption operation provides integrity protection
+	// There is NO separate checksum (EC=0 is correct for sealed tokens)
+	// For integrity-only tokens, we need to verify the outer checksum
+	isConfidentialityToken := (token.Flags&0x02) != 0 && token.EC == 0
+	if isConfidentialityToken {
+		debugLog("UNWRAP: Confidentiality token (sealed + EC=0), skipping outer checksum verification")
+		debugLog("UNWRAP: Integrity will be verified during decryption")
+	} else if token.EC > 0 {
+		// Verify outer checksum for integrity-only tokens
+		keyUsage := s.getKeyUsage(false)
+		debugLog("UNWRAP: Integrity-only token, verifying outer checksum with key usage=%d", keyUsage)
+		valid, err := token.Verify(s.key, keyUsage)
+		if err != nil {
+			debugLog("UNWRAP: Checksum verification ERROR: %v", err)
+			return nil, fmt.Errorf("failed to verify checksum: %w", err)
+		}
+		if !valid {
+			debugLog("UNWRAP: Checksum verification FAILED")
+			return nil, errors.New("checksum verification failed")
+		}
+		debugLog("UNWRAP: Checksum verification SUCCESS")
+	}
+
+	// Extract payload - decrypt if sealed
+	payload := token.Payload
+	if token.Flags&0x02 != 0 { // Sealed flag is bit 1
+		debugLog("UNWRAP: Sealed flag set, decrypting payload")
+		keyUsage := s.getKeyUsage(false)
+		debugLog("UNWRAP: Key usage for decryption=%d", keyUsage)
+		decryptedPayload, err := s.encType.DecryptMessage(s.key.KeyValue, token.Payload, keyUsage)
+		if err != nil {
+			debugLog("UNWRAP: Decryption FAILED: %v", err)
+			return nil, fmt.Errorf("failed to decrypt payload: %w", err)
+		}
+		debugLog("UNWRAP: Decrypted payload length=%d", len(decryptedPayload))
+
+		// RFC 4121: Decrypted data is: plaintext | filler | embedded-header
+		// EC field contains the filler size, embedded header is always 16 bytes
+		// We need to strip the last (EC + 16) bytes to get the actual plaintext
+		stripBytes := int(token.EC) + 16
+		if len(decryptedPayload) < stripBytes {
+			debugLog("UNWRAP: Decrypted payload too short: got %d bytes, need at least %d", len(decryptedPayload), stripBytes)
+			return nil, fmt.Errorf("decrypted payload too short: %d bytes, expected at least %d", len(decryptedPayload), stripBytes)
+		}
+		payload = decryptedPayload[:len(decryptedPayload)-stripBytes]
+		debugLog("UNWRAP: Stripped %d bytes (EC=%d filler + 16 byte embedded header), final payload length=%d",
+			stripBytes, token.EC, len(payload))
+	} else {
+		debugLog("UNWRAP: No decryption needed (integrity layer)")
+	}
+
+	// Check message size if limit is set
+	if s.maxMessageSize > 0 && len(payload) > s.maxMessageSize {
+		debugLog("UNWRAP: Message size check FAILED: %d exceeds maximum %d", len(payload), s.maxMessageSize)
+		return nil, fmt.Errorf("message size %d exceeds maximum %d", len(payload), s.maxMessageSize)
+	}
+
+	debugLog("UNWRAP: Extracted payload length=%d", len(payload))
+	debugLog("UNWRAP: Extracted payload (first %d bytes hex)=%x", min(len(payload), 100), payload[:min(len(payload), 100)])
+	debugLog("UNWRAP: SUCCESS")
+
+	return payload, nil
+}
+
+// getKeyUsage returns the appropriate key usage constant based on direction.
+func (s *SecurityLayerSession) getKeyUsage(sending bool) uint32 {
+	if sending {
+		if s.isInitiator {
+			return keyusage.GSSAPI_INITIATOR_SEAL
+		}
+		return keyusage.GSSAPI_ACCEPTOR_SEAL
+	}
+	// Receiving: opposite of sending
+	if s.isInitiator {
+		return keyusage.GSSAPI_ACCEPTOR_SEAL
+	}
+	return keyusage.GSSAPI_INITIATOR_SEAL
+}
+
+// WrapWithSASLFraming wraps a message and prepends the 4-byte SASL length header.
+// This is the format required by SASL protocols like LDAP with security layers.
+// Format: [4-byte length (big-endian)][wrapped GSS-API token]
+func (s *SecurityLayerSession) WrapWithSASLFraming(message []byte) ([]byte, error) {
+	debugLog("SASL_WRAP: Input message length=%d", len(message))
+
+	wrappedToken, err := s.Wrap(message)
+	if err != nil {
+		debugLog("SASL_WRAP: Wrap FAILED: %v", err)
+		return nil, err
+	}
+
+	debugLog("SASL_WRAP: Wrapped token length=%d", len(wrappedToken))
+
+	// Prepend 4-byte length header
+	frameLength := uint32(len(wrappedToken))
+	framedMessage := make([]byte, 4+len(wrappedToken))
+	binary.BigEndian.PutUint32(framedMessage[0:4], frameLength)
+	copy(framedMessage[4:], wrappedToken)
+
+	debugLog("SASL_WRAP: SASL frame length=%d (0x%08x)", frameLength, frameLength)
+	debugLog("SASL_WRAP: Final framed message length=%d (4-byte header + %d-byte token)", len(framedMessage), len(wrappedToken))
+	debugLog("SASL_WRAP: Frame header (hex)=%x", framedMessage[0:4])
+	debugLog("SASL_WRAP: SUCCESS")
+
+	return framedMessage, nil
+}
+
+// UnwrapFromSASLFraming reads a SASL-framed message and unwraps it.
+// This reads the 4-byte length header, then reads that many bytes and unwraps them.
+// The reader parameter should be positioned at the start of a SASL-framed message.
+func (s *SecurityLayerSession) UnwrapFromSASLFraming(reader io.Reader) ([]byte, error) {
+	debugLog("SASL_UNWRAP: Reading SASL frame header (4 bytes)")
+
+	// Read 4-byte length header
+	var lengthBytes [4]byte
+	if _, err := io.ReadFull(reader, lengthBytes[:]); err != nil {
+		debugLog("SASL_UNWRAP: Failed to read frame length: %v", err)
+		return nil, fmt.Errorf("failed to read SASL frame length: %w", err)
+	}
+
+	messageLength := binary.BigEndian.Uint32(lengthBytes[:])
+	debugLog("SASL_UNWRAP: SASL frame length=%d (0x%08x)", messageLength, messageLength)
+	debugLog("SASL_UNWRAP: Frame header (hex)=%x", lengthBytes[:])
+
+	// Sanity check on message length
+	if messageLength == 0 {
+		debugLog("SASL_UNWRAP: Invalid frame length: 0")
+		return nil, errors.New("invalid SASL frame length: 0")
+	}
+	if messageLength > 1<<24 { // 16MB limit
+		debugLog("SASL_UNWRAP: Frame length too large: %d (max 16MB)", messageLength)
+		return nil, fmt.Errorf("SASL frame length too large: %d", messageLength)
+	}
+
+	debugLog("SASL_UNWRAP: Reading wrapped message (%d bytes)", messageLength)
+
+	// Read the wrapped message
+	wrappedMessage := make([]byte, messageLength)
+	if _, err := io.ReadFull(reader, wrappedMessage); err != nil {
+		debugLog("SASL_UNWRAP: Failed to read wrapped message: %v", err)
+		return nil, fmt.Errorf("failed to read wrapped message: %w", err)
+	}
+
+	debugLog("SASL_UNWRAP: Read %d bytes, unwrapping...", len(wrappedMessage))
+
+	// Unwrap the message
+	payload, err := s.Unwrap(wrappedMessage)
+	if err != nil {
+		debugLog("SASL_UNWRAP: Unwrap FAILED: %v", err)
+		return nil, err
+	}
+
+	debugLog("SASL_UNWRAP: SUCCESS, payload length=%d", len(payload))
+	return payload, nil
+}
+
+// SecureConn wraps a net.Conn to provide transparent SASL security layer protection.
+// All data written is automatically wrapped, and all data read is automatically unwrapped.
+// This implements the net.Conn interface.
+type SecureConn struct {
+	conn    net.Conn
+	session *SecurityLayerSession
+	readBuf []byte // Buffer for partially read unwrapped messages
+}
+
+// NewSecureConn creates a new SecureConn that wraps the provided connection.
+// The session parameter configures the security layer behavior.
+//
+// WARNING: Microsoft Active Directory (per MS-ADTS) prohibits using SASL
+// security layers (integrity/confidentiality) over TLS connections and will
+// reject such connections. If a TLS connection is detected with an integrity
+// or confidentiality layer, a warning will be logged to stderr by default.
+// Set GOKRB5_SASL_TLS_NO_WARN=1 to suppress this warning if connecting to
+// non-AD services that accept this configuration per RFC 4513.
+func NewSecureConn(conn net.Conn, session *SecurityLayerSession) *SecureConn {
+	// Check if the connection is TLS and warn about Active Directory incompatibility
+	if _, isTLS := conn.(*tls.Conn); isTLS {
+		if session.layer == SecurityLayerIntegrity || session.layer == SecurityLayerConfidentiality {
+			// Warn by default unless explicitly suppressed
+			if os.Getenv("GOKRB5_SASL_TLS_NO_WARN") != "1" {
+				fmt.Fprintf(os.Stderr, "[GOKRB5 WARNING] Using SASL security layer over TLS connection. "+
+					"Microsoft Active Directory (MS-ADTS) prohibits this combination and will reject the connection. "+
+					"Other LDAP servers may accept this per RFC 4513. "+
+					"Set GOKRB5_SASL_TLS_NO_WARN=1 to suppress this warning.\n")
+			}
+		}
+	}
+
+	return &SecureConn{
+		conn:    conn,
+		session: session,
+		readBuf: make([]byte, 0),
+	}
+}
+
+// Read reads data from the connection, automatically unwrapping SASL-framed messages.
+// It implements the net.Conn Read method.
+func (sc *SecureConn) Read(b []byte) (int, error) {
+	// If we have buffered data from a previous unwrap, return that first
+	if len(sc.readBuf) > 0 {
+		n := copy(b, sc.readBuf)
+		sc.readBuf = sc.readBuf[n:]
+		return n, nil
+	}
+
+	// Read and unwrap a complete SASL-framed message
+	unwrapped, err := sc.session.UnwrapFromSASLFraming(sc.conn)
+	if err != nil {
+		return 0, err
+	}
+
+	// Copy as much as we can to the caller's buffer
+	n := copy(b, unwrapped)
+	if n < len(unwrapped) {
+		// Store remainder for next Read call
+		sc.readBuf = append(sc.readBuf, unwrapped[n:]...)
+	}
+
+	return n, nil
+}
+
+// Write writes data to the connection, automatically wrapping with SASL framing.
+// It implements the net.Conn Write method.
+func (sc *SecureConn) Write(b []byte) (int, error) {
+	wrapped, err := sc.session.WrapWithSASLFraming(b)
+	if err != nil {
+		return 0, err
+	}
+
+	// Write the complete wrapped message
+	if _, err := sc.conn.Write(wrapped); err != nil {
+		return 0, err
+	}
+
+	// Return the number of unwrapped bytes written (not the wrapped size)
+	return len(b), nil
+}
+
+// Close closes the underlying connection.
+func (sc *SecureConn) Close() error {
+	return sc.conn.Close()
+}
+
+// LocalAddr returns the local network address.
+func (sc *SecureConn) LocalAddr() net.Addr {
+	return sc.conn.LocalAddr()
+}
+
+// RemoteAddr returns the remote network address.
+func (sc *SecureConn) RemoteAddr() net.Addr {
+	return sc.conn.RemoteAddr()
+}
+
+// SetDeadline sets the read and write deadlines.
+func (sc *SecureConn) SetDeadline(t time.Time) error {
+	return sc.conn.SetDeadline(t)
+}
+
+// SetReadDeadline sets the read deadline.
+func (sc *SecureConn) SetReadDeadline(t time.Time) error {
+	return sc.conn.SetReadDeadline(t)
+}
+
+// SetWriteDeadline sets the write deadline.
+func (sc *SecureConn) SetWriteDeadline(t time.Time) error {
+	return sc.conn.SetWriteDeadline(t)
+}

--- a/v8/gssapi/securitylayer_example_test.go
+++ b/v8/gssapi/securitylayer_example_test.go
@@ -1,0 +1,201 @@
+package gssapi_test
+
+import (
+	"fmt"
+	"log"
+	"net"
+
+	"github.com/jcmturner/gokrb5/v8/gssapi"
+	"github.com/jcmturner/gokrb5/v8/types"
+)
+
+// ExampleSecurityLayerSession_basic demonstrates basic wrapping and unwrapping of messages
+func ExampleSecurityLayerSession_basic() {
+	// Assume we have obtained a session key from Kerberos authentication
+	sessionKey := types.EncryptionKey{
+		KeyType:  17, // AES128-CTS-HMAC-SHA1-96
+		KeyValue: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+	}
+
+	// Create a security layer session with integrity protection
+	session, err := gssapi.NewSecurityLayerSession(
+		sessionKey,
+		gssapi.SecurityLayerIntegrity,
+		true, // isInitiator (client)
+		0,    // maxMessageSize (0 = unlimited)
+	)
+	if err != nil {
+		log.Fatalf("Failed to create session: %v", err)
+	}
+
+	// Wrap a message
+	message := []byte("Hello, SASL Security Layer!")
+	wrapped, err := session.Wrap(message)
+	if err != nil {
+		log.Fatalf("Failed to wrap message: %v", err)
+	}
+
+	fmt.Printf("Original message: %s\n", message)
+	fmt.Printf("Wrapped message length: %d bytes (greater than original)\n", len(wrapped))
+
+	// On the receiving side, create a corresponding session
+	serverSession, err := gssapi.NewSecurityLayerSession(
+		sessionKey,
+		gssapi.SecurityLayerIntegrity,
+		false, // isInitiator = false (server/acceptor)
+		0,
+	)
+	if err != nil {
+		log.Fatalf("Failed to create server session: %v", err)
+	}
+
+	// Unwrap the message
+	unwrapped, err := serverSession.Unwrap(wrapped)
+	if err != nil {
+		log.Fatalf("Failed to unwrap message: %v", err)
+	}
+
+	fmt.Printf("Unwrapped message: %s\n", unwrapped)
+	// Output:
+	// Original message: Hello, SASL Security Layer!
+	// Wrapped message length: 55 bytes (greater than original)
+	// Unwrapped message: Hello, SASL Security Layer!
+}
+
+// ExampleSecurityLayerSession_saslFraming demonstrates SASL-framed messages
+// This is the format used by protocols like LDAP with security layers
+func ExampleSecurityLayerSession_saslFraming() {
+	sessionKey := types.EncryptionKey{
+		KeyType:  17,
+		KeyValue: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+	}
+
+	// Create client session
+	clientSession, err := gssapi.NewSecurityLayerSession(
+		sessionKey,
+		gssapi.SecurityLayerIntegrity,
+		true,
+		0,
+	)
+	if err != nil {
+		log.Fatalf("Failed to create client session: %v", err)
+	}
+
+	// Wrap message with SASL framing (4-byte length prefix)
+	message := []byte("LDAP Search Request")
+	framedMessage, err := clientSession.WrapWithSASLFraming(message)
+	if err != nil {
+		log.Fatalf("Failed to wrap with SASL framing: %v", err)
+	}
+
+	fmt.Printf("Message: %s\n", message)
+	fmt.Printf("Framed message has 4-byte length header plus wrapped token\n")
+	fmt.Printf("Total framed length: %d bytes\n", len(framedMessage))
+
+	// Output:
+	// Message: LDAP Search Request
+	// Framed message has 4-byte length header plus wrapped token
+	// Total framed length: 51 bytes
+}
+
+// ExampleSecureConn demonstrates transparent wrapping/unwrapping with a network connection
+// This is the easiest way to integrate SASL security layers into existing code
+func ExampleSecureConn() {
+	sessionKey := types.EncryptionKey{
+		KeyType:  17,
+		KeyValue: []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09, 0x0a, 0x0b, 0x0c, 0x0d, 0x0e, 0x0f, 0x10},
+	}
+
+	// Assume we have a net.Conn from LDAP connection
+	var rawConn net.Conn // This would be your actual LDAP connection
+
+	// After successful GSSAPI authentication and security layer negotiation,
+	// wrap the connection with SecureConn
+	clientSession, err := gssapi.NewSecurityLayerSession(
+		sessionKey,
+		gssapi.SecurityLayerIntegrity,
+		true,
+		0,
+	)
+	if err != nil {
+		log.Fatalf("Failed to create session: %v", err)
+	}
+
+	// Wrap the raw connection
+	secureConn := gssapi.NewSecureConn(rawConn, clientSession)
+
+	// Now you can use secureConn like any net.Conn
+	// All writes are automatically wrapped, all reads are automatically unwrapped
+
+	// Example write (this would be an LDAP message in real usage)
+	message := []byte("LDAP operation")
+	_, err = secureConn.Write(message)
+	if err != nil {
+		log.Fatalf("Failed to write: %v", err)
+	}
+
+	// Example read (this would read an LDAP response in real usage)
+	buffer := make([]byte, 4096)
+	_, err = secureConn.Read(buffer)
+	if err != nil {
+		log.Fatalf("Failed to read: %v", err)
+	}
+
+	// Close when done
+	secureConn.Close()
+}
+
+// ExampleSecurityLayerSession_ldapIntegration demonstrates how to integrate with go-ldap
+func ExampleSecurityLayerSession_ldapIntegration() {
+	// This is a conceptual example of how to integrate with go-ldap/ldap
+	// After implementing security layer negotiation in go-ldap's GSSAPI bind:
+
+	/*
+		// 1. Perform GSSAPI bind and negotiate security layer
+		bindRequest := &ldap.GSSAPIBindRequest{
+			SecurityLayerPreference: &ldap.SecurityLayerPreference{
+				PreferIntegrity:        true,
+				PreferConfidentiality:  false,
+				MaxReceiveBuffer:       65536,
+			},
+		}
+
+		// 2. After successful bind, extract the session key from the Kerberos context
+		sessionKey := extractSessionKeyFromKerberosContext(...)
+
+		// 3. Determine the negotiated security layer
+		negotiatedLayer := gssapi.SecurityLayerIntegrity // or SecurityLayerConfidentiality
+
+		// 4. Create a security layer session
+		session, err := gssapi.NewSecurityLayerSession(
+			sessionKey,
+			negotiatedLayer,
+			true, // client is initiator
+			65536, // max message size
+		)
+		if err != nil {
+			log.Fatalf("Failed to create security layer session: %v", err)
+		}
+
+		// 5. Wrap the LDAP connection
+		secureConn := gssapi.NewSecureConn(ldapConn.Conn, session)
+
+		// 6. Replace the LDAP connection's net.Conn with the SecureConn
+		ldapConn.Conn = secureConn
+
+		// 7. Now all subsequent LDAP operations will be transparently wrapped/unwrapped
+		searchRequest := ldap.NewSearchRequest(
+			"dc=example,dc=com",
+			ldap.ScopeWholeSubtree, ldap.NeverDerefAliases, 0, 0, false,
+			"(objectClass=*)",
+			[]string{"dn"},
+			nil,
+		)
+
+		sr, err := ldapConn.Search(searchRequest)
+		// The search request is automatically wrapped, response is automatically unwrapped
+	*/
+
+	fmt.Println("See code comments for integration pattern")
+	// Output: See code comments for integration pattern
+}

--- a/v8/gssapi/securitylayer_rfc4121_test.go
+++ b/v8/gssapi/securitylayer_rfc4121_test.go
@@ -1,0 +1,452 @@
+package gssapi
+
+import (
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
+	"github.com/jcmturner/gokrb5/v8/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RFC 4121 Compliance Tests
+// These tests verify that our implementation follows RFC 4121 precisely.
+
+// getTestKey returns a test encryption key for testing
+func getTestKey() types.EncryptionKey {
+	key, _ := hex.DecodeString("14f9bde6b50ec508201a97f74c4e5bd3")
+	return types.EncryptionKey{
+		KeyType:  17, // AES128-CTS-HMAC-SHA1-96
+		KeyValue: key,
+	}
+}
+
+// TestRFC4121_TokenIDFormat verifies token ID is 0x05 0x04 per RFC 4121 section 4.2.6.2
+func TestRFC4121_TokenIDFormat(t *testing.T) {
+	key := getTestKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("test message")
+	wrapped, err := session.Wrap(message)
+	require.NoError(t, err)
+
+	// First two bytes must be 0x05 0x04
+	assert.Equal(t, byte(0x05), wrapped[0], "Token ID byte 0 must be 0x05")
+	assert.Equal(t, byte(0x04), wrapped[1], "Token ID byte 1 must be 0x04")
+}
+
+// TestRFC4121_FillerByteFormat verifies filler byte is 0xFF per RFC 4121 section 4.2.6.2
+func TestRFC4121_FillerByteFormat(t *testing.T) {
+	key := getTestKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("test message")
+	wrapped, err := session.Wrap(message)
+	require.NoError(t, err)
+
+	// Byte 3 (index 3) must be 0xFF
+	assert.Equal(t, byte(0xFF), wrapped[3], "Filler byte must be 0xFF")
+}
+
+// TestRFC4121_KeyUsageValues verifies correct key usage values per RFC 4121 section 2
+func TestRFC4121_KeyUsageValues(t *testing.T) {
+	// Verify constants match RFC 4121 section 2
+	assert.Equal(t, uint32(22), uint32(keyusage.GSSAPI_ACCEPTOR_SEAL), "KG-USAGE-ACCEPTOR-SEAL must be 22")
+	assert.Equal(t, uint32(24), uint32(keyusage.GSSAPI_INITIATOR_SEAL), "KG-USAGE-INITIATOR-SEAL must be 24")
+}
+
+// TestRFC4121_ECField_IntegrityToken verifies EC field for integrity tokens
+// Per RFC 4121 section 4.2.3: "the number of octets in the trailing checksum"
+func TestRFC4121_ECField_IntegrityToken(t *testing.T) {
+	key := getTestKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("test message")
+	wrapped, err := session.Wrap(message)
+	require.NoError(t, err)
+
+	// Extract EC field (bytes 4-5, big-endian)
+	ec := binary.BigEndian.Uint16(wrapped[4:6])
+
+	// EC should be the checksum size (12 bytes for AES128-CTS-HMAC-SHA1-96)
+	expectedChecksumSize := uint16(12)
+	assert.Equal(t, expectedChecksumSize, ec, "EC field must equal checksum size for integrity tokens")
+
+	// Verify the actual checksum length matches EC
+	// Token structure: [16-byte header][payload][checksum]
+	// Checksum is the last EC bytes
+	actualChecksumSize := len(wrapped) - 16 - len(message)
+	assert.Equal(t, int(ec), actualChecksumSize, "Actual checksum size must match EC field")
+}
+
+// TestRFC4121_ECField_ConfidentialityToken verifies EC field for confidentiality tokens
+// Per RFC 4121 section 4.2.3: "the number of octets in the filler"
+func TestRFC4121_ECField_ConfidentialityToken(t *testing.T) {
+	key := getTestKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("test message")
+	wrapped, err := session.Wrap(message)
+	require.NoError(t, err)
+
+	// Extract EC field (bytes 4-5, big-endian)
+	ec := binary.BigEndian.Uint16(wrapped[4:6])
+
+	// For our implementation, we use 0 filler bytes
+	expectedFillerSize := uint16(0)
+	assert.Equal(t, expectedFillerSize, ec, "EC field must equal filler size for confidentiality tokens")
+}
+
+// TestRFC4121_RRCField_Format verifies RRC field format (bytes 6-7, big-endian)
+func TestRFC4121_RRCField_Format(t *testing.T) {
+	key := getTestKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("test message")
+	wrapped, err := session.Wrap(message)
+	require.NoError(t, err)
+
+	// Extract RRC field (bytes 6-7, big-endian)
+	rrc := binary.BigEndian.Uint16(wrapped[6:8])
+
+	// Our implementation sets RRC to 0 for outgoing messages
+	assert.Equal(t, uint16(0), rrc, "RRC field should be 0 for non-rotated tokens")
+}
+
+// TestRFC4121_SequenceNumberFormat verifies sequence number field (bytes 8-15, big-endian)
+func TestRFC4121_SequenceNumberFormat(t *testing.T) {
+	key := getTestKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	// First message should have sequence number 0
+	message1 := []byte("message 1")
+	wrapped1, err := session.Wrap(message1)
+	require.NoError(t, err)
+
+	seqNum1 := binary.BigEndian.Uint64(wrapped1[8:16])
+	assert.Equal(t, uint64(0), seqNum1, "First message should have sequence number 0")
+
+	// Second message should have sequence number 1
+	message2 := []byte("message 2")
+	wrapped2, err := session.Wrap(message2)
+	require.NoError(t, err)
+
+	seqNum2 := binary.BigEndian.Uint64(wrapped2[8:16])
+	assert.Equal(t, uint64(1), seqNum2, "Second message should have sequence number 1")
+}
+
+// TestRFC4121_FlagsField_Acceptor verifies acceptor flag (bit 0 of flags byte)
+func TestRFC4121_FlagsField_Acceptor(t *testing.T) {
+	key := getTestKey()
+
+	t.Run("Initiator sets acceptor bit to 0", func(t *testing.T) {
+		session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+		require.NoError(t, err)
+
+		wrapped, err := session.Wrap([]byte("test"))
+		require.NoError(t, err)
+
+		flags := wrapped[2]
+		acceptorBit := flags & 0x01
+		assert.Equal(t, byte(0), acceptorBit, "Initiator must set acceptor bit to 0")
+	})
+
+	t.Run("Acceptor sets acceptor bit to 1", func(t *testing.T) {
+		session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+		require.NoError(t, err)
+
+		wrapped, err := session.Wrap([]byte("test"))
+		require.NoError(t, err)
+
+		flags := wrapped[2]
+		acceptorBit := flags & 0x01
+		assert.Equal(t, byte(1), acceptorBit, "Acceptor must set acceptor bit to 1")
+	})
+}
+
+// TestRFC4121_FlagsField_Sealed verifies sealed flag (bit 1 of flags byte)
+func TestRFC4121_FlagsField_Sealed(t *testing.T) {
+	key := getTestKey()
+
+	t.Run("Integrity layer sets sealed bit to 0", func(t *testing.T) {
+		session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+		require.NoError(t, err)
+
+		wrapped, err := session.Wrap([]byte("test"))
+		require.NoError(t, err)
+
+		flags := wrapped[2]
+		sealedBit := (flags & 0x02) >> 1
+		assert.Equal(t, byte(0), sealedBit, "Integrity layer must set sealed bit to 0")
+	})
+
+	t.Run("Confidentiality layer sets sealed bit to 1", func(t *testing.T) {
+		session, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+		require.NoError(t, err)
+
+		wrapped, err := session.Wrap([]byte("test"))
+		require.NoError(t, err)
+
+		flags := wrapped[2]
+		sealedBit := (flags & 0x02) >> 1
+		assert.Equal(t, byte(1), sealedBit, "Confidentiality layer must set sealed bit to 1")
+	})
+}
+
+// TestRFC4121_IntegrityTokenStructure verifies unsealed token structure
+// Per RFC 4121 section 4.2.6.2: {header | plaintext-data | get_mic(plaintext-data | header)}
+func TestRFC4121_IntegrityTokenStructure(t *testing.T) {
+	key := getTestKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("plaintext message")
+	wrapped, err := session.Wrap(message)
+	require.NoError(t, err)
+
+	// Token should be: [16-byte header][plaintext][12-byte checksum]
+	require.GreaterOrEqual(t, len(wrapped), 16+len(message)+12)
+
+	// Extract components
+	header := wrapped[:16]
+	ec := binary.BigEndian.Uint16(header[4:6])
+	checksumSize := int(ec)
+
+	// Payload should be plaintext (not encrypted)
+	payloadStart := 16
+	payloadEnd := len(wrapped) - checksumSize
+	payload := wrapped[payloadStart:payloadEnd]
+
+	assert.Equal(t, message, payload, "Payload should be plaintext for integrity tokens")
+}
+
+// TestRFC4121_ConfidentialityTokenStructure verifies sealed token structure
+// Per RFC 4121 section 4.2.4: {header | encrypt(plaintext-data | filler | header)}
+func TestRFC4121_ConfidentialityTokenStructure(t *testing.T) {
+	key := getTestKey()
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, false, 0)
+	require.NoError(t, err)
+
+	message := []byte("secret message")
+	wrapped, err := clientSession.Wrap(message)
+	require.NoError(t, err)
+
+	// Token should be: [16-byte header][encrypted data]
+	require.Greater(t, len(wrapped), 16)
+
+	// Payload should NOT be plaintext (should be encrypted)
+	payload := wrapped[16:]
+	assert.NotEqual(t, message, payload, "Payload should be encrypted for confidentiality tokens")
+
+	// Verify we can decrypt it properly
+	unwrapped, err := serverSession.Unwrap(wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, message, unwrapped, "Unwrapped message should match original")
+}
+
+// TestRFC4121_ChecksumComputationWithZeroedFields verifies checksum is computed with EC/RRC zeroed
+// Per RFC 4121 section 4.2.6.2: "Both the EC field and the RRC field in the token header
+// SHALL be filled with zeroes for the purpose of calculating the checksum."
+func TestRFC4121_ChecksumComputationWithZeroedFields(t *testing.T) {
+	key := getTestKey()
+	message := []byte("test message")
+
+	// Create a wrap token manually
+	token := &WrapToken{
+		Flags:     0x00,
+		EC:        12,
+		RRC:       0,
+		SndSeqNum: 0,
+		Payload:   message,
+	}
+
+	// Compute checksum (should use zeroed EC/RRC)
+	err := token.SetCheckSum(key, keyusage.GSSAPI_INITIATOR_SEAL)
+	require.NoError(t, err)
+
+	// Verify the checksum (the Verify method should also use zeroed EC/RRC)
+	valid, err := token.Verify(key, keyusage.GSSAPI_INITIATOR_SEAL)
+	require.NoError(t, err)
+	assert.True(t, valid, "Checksum verification should succeed")
+}
+
+// TestRFC4121_RRC_Rotation verifies RRC rotation per RFC 4121 section 4.2.5
+// "token {header | aa | bb | cc | dd | ee | ff | gg | hh} with RRC=3
+// becomes {header | ff | gg | hh | aa | bb | cc | dd | ee}"
+func TestRFC4121_RRC_Rotation(t *testing.T) {
+	// Create a simulated rotated token to test our un-rotation logic
+	key := getTestKey()
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	message := []byte("test message for rotation")
+
+	// Wrap the message normally (RRC=0)
+	wrapped, err := clientSession.Wrap(message)
+	require.NoError(t, err)
+
+	// Extract components
+	data := wrapped[16:] // This includes payload + checksum (skip header)
+
+	// Simulate rotation: manually rotate the data section
+	// For RRC=3, last 3 bytes move to front
+	rrc := 3
+	if len(data) > rrc {
+		rotated := make([]byte, len(wrapped))
+		copy(rotated[:16], wrapped[:16]) // Copy header
+		// Rotate: last RRC bytes go first, then the rest
+		copy(rotated[16:16+rrc], data[len(data)-rrc:])
+		copy(rotated[16+rrc:], data[:len(data)-rrc])
+
+		// Update RRC field in header
+		binary.BigEndian.PutUint16(rotated[6:8], uint16(rrc))
+
+		// Try to unwrap the rotated token
+		unwrapped, err := serverSession.Unwrap(rotated)
+		require.NoError(t, err)
+		assert.Equal(t, message, unwrapped, "Should correctly unwrap rotated token")
+	}
+}
+
+// TestRFC4121_RRC_LargeRotationValues tests that we can handle RRC > data length
+// Per RFC 4121 section 4.2.5: "Receivers MUST be able to interpret all possible
+// rotation count values, including rotation counts greater than the length of the token."
+func TestRFC4121_RRC_LargeRotationValues(t *testing.T) {
+	key := getTestKey()
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	message := []byte("short")
+
+	// Wrap normally
+	wrapped, err := clientSession.Wrap(message)
+	require.NoError(t, err)
+
+	data := wrapped[16:]
+
+	// Test with RRC > data length (should be handled gracefully)
+	// RFC doesn't specify exact behavior, but we should not panic
+	rrc := len(data) + 10
+
+	rotated := make([]byte, len(wrapped))
+	copy(rotated, wrapped)
+	binary.BigEndian.PutUint16(rotated[6:8], uint16(rrc))
+
+	// This might fail, but it shouldn't panic
+	_, err = serverSession.Unwrap(rotated)
+	// We just verify it doesn't panic - error is acceptable for invalid RRC
+	if err != nil {
+		t.Logf("Expected behavior: RRC > data length resulted in error: %v", err)
+	}
+}
+
+// TestRFC4121_SequenceNumberOrdering verifies sequence number validation
+func TestRFC4121_SequenceNumberOrdering(t *testing.T) {
+	key := getTestKey()
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	// Send messages in order
+	msg1, _ := clientSession.Wrap([]byte("message 1"))
+	msg2, _ := clientSession.Wrap([]byte("message 2"))
+	msg3, _ := clientSession.Wrap([]byte("message 3"))
+
+	// Receive in order - should succeed
+	_, err = serverSession.Unwrap(msg1)
+	assert.NoError(t, err)
+
+	_, err = serverSession.Unwrap(msg2)
+	assert.NoError(t, err)
+
+	_, err = serverSession.Unwrap(msg3)
+	assert.NoError(t, err)
+
+	// Try to replay msg1 (old sequence number) - should fail
+	_, err = serverSession.Unwrap(msg1)
+	assert.Error(t, err, "Replayed message with old sequence number should be rejected")
+}
+
+// TestRFC4121_BigEndianEncoding verifies all multi-byte fields are big-endian
+func TestRFC4121_BigEndianEncoding(t *testing.T) {
+	key := getTestKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	// Set a non-zero sequence number
+	session.sendSeqNum = 0x0102030405060708
+
+	wrapped, err := session.Wrap([]byte("test"))
+	require.NoError(t, err)
+
+	// Verify EC field is big-endian (bytes 4-5)
+	ec := binary.BigEndian.Uint16(wrapped[4:6])
+	assert.Equal(t, uint16(12), ec) // 12 bytes for HMAC
+
+	// Verify RRC field is big-endian (bytes 6-7)
+	rrc := binary.BigEndian.Uint16(wrapped[6:8])
+	assert.Equal(t, uint16(0), rrc)
+
+	// Verify sequence number is big-endian (bytes 8-15)
+	seqNum := binary.BigEndian.Uint64(wrapped[8:16])
+	assert.Equal(t, uint64(0x0102030405060708), seqNum)
+}
+
+// TestRFC4121_HeaderLength verifies header is exactly 16 octets
+func TestRFC4121_HeaderLength(t *testing.T) {
+	// Header structure from RFC 4121:
+	// 0-1: TOK_ID (2 bytes)
+	// 2: Flags (1 byte)
+	// 3: Filler (1 byte)
+	// 4-5: EC (2 bytes)
+	// 6-7: RRC (2 bytes)
+	// 8-15: SND_SEQ (8 bytes)
+	// Total: 16 bytes
+
+	assert.Equal(t, 16, HdrLen, "Header length must be exactly 16 octets per RFC 4121")
+}
+
+// TestRFC4121_NoChecksumForConfidentiality verifies no outer checksum for sealed tokens
+// Per RFC 4121: For confidentiality, encryption provides integrity
+func TestRFC4121_NoChecksumForConfidentiality(t *testing.T) {
+	key := getTestKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("confidential message")
+	wrapped, err := session.Wrap(message)
+	require.NoError(t, err)
+
+	// For confidentiality tokens, there should be no trailing checksum
+	// Token structure: [16-byte header][encrypted data]
+	// The encrypted data contains: encrypt(message | filler | embedded-header)
+
+	// EC field should be 0 (no filler) or a small value
+	ec := binary.BigEndian.Uint16(wrapped[4:6])
+	assert.Equal(t, uint16(0), ec, "EC should indicate filler size (0 for no filler)")
+
+	// There should be no trailing checksum like in integrity tokens
+	// The token length should be: 16 (header) + encrypted_size
+	// where encrypted_size = len(message) + filler + 16 (embedded header) + block padding
+	minExpectedLen := 16 + len(message) + int(ec) + 16 // header + message + filler + embedded header
+	assert.GreaterOrEqual(t, len(wrapped), minExpectedLen, "Token should contain header + encrypted data")
+}

--- a/v8/gssapi/securitylayer_rfc4121_test.go
+++ b/v8/gssapi/securitylayer_rfc4121_test.go
@@ -1,6 +1,7 @@
 package gssapi
 
 import (
+	"bytes"
 	"encoding/binary"
 	"encoding/hex"
 	"testing"
@@ -449,4 +450,174 @@ func TestRFC4121_NoChecksumForConfidentiality(t *testing.T) {
 	// where encrypted_size = len(message) + filler + 16 (embedded header) + block padding
 	minExpectedLen := 16 + len(message) + int(ec) + 16 // header + message + filler + embedded header
 	assert.GreaterOrEqual(t, len(wrapped), minExpectedLen, "Token should contain header + encrypted data")
+}
+
+// TestRFC4121_ZeroCryptoSystemResidue verifies RFC 4121 section 4.2.4 requirement:
+// "The values and size of the filler octets are chosen by implementations,
+// such that there SHALL be no crypto-system residue present after the decryption."
+//
+// This test ensures that after wrap/unwrap, the decrypted message is exactly
+// the original message with no trailing padding bytes from the crypto layer.
+func TestRFC4121_ZeroCryptoSystemResidue(t *testing.T) {
+	key := getTestKey()
+
+	// Test various message lengths that would require different alignments
+	// for block ciphers. For AES-CTS (used in getTestKey), filler should be 0.
+	// For DES3 (8-byte blocks), these lengths would require different filler amounts.
+	testCases := []struct {
+		name      string
+		length    int
+		createMsg func(int) []byte
+	}{
+		{
+			name:   "1 byte message",
+			length: 1,
+			createMsg: func(n int) []byte {
+				return []byte{0x01}
+			},
+		},
+		{
+			name:   "7 byte message (one before 8-byte boundary)",
+			length: 7,
+			createMsg: func(n int) []byte {
+				return []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07}
+			},
+		},
+		{
+			name:   "8 byte message (exactly 8-byte boundary)",
+			length: 8,
+			createMsg: func(n int) []byte {
+				return []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08}
+			},
+		},
+		{
+			name:   "9 byte message (one after 8-byte boundary)",
+			length: 9,
+			createMsg: func(n int) []byte {
+				return []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09}
+			},
+		},
+		{
+			name:   "15 byte message",
+			length: 15,
+			createMsg: func(n int) []byte {
+				msg := make([]byte, n)
+				for i := 0; i < n; i++ {
+					msg[i] = byte(i + 1)
+				}
+				return msg
+			},
+		},
+		{
+			name:   "16 byte message (exactly 16-byte boundary)",
+			length: 16,
+			createMsg: func(n int) []byte {
+				msg := make([]byte, n)
+				for i := 0; i < n; i++ {
+					msg[i] = byte(i + 1)
+				}
+				return msg
+			},
+		},
+		{
+			name:   "17 byte message",
+			length: 17,
+			createMsg: func(n int) []byte {
+				msg := make([]byte, n)
+				for i := 0; i < n; i++ {
+					msg[i] = byte(i + 1)
+				}
+				return msg
+			},
+		},
+		{
+			name:   "23 byte message",
+			length: 23,
+			createMsg: func(n int) []byte {
+				msg := make([]byte, n)
+				for i := 0; i < n; i++ {
+					msg[i] = byte(i + 1)
+				}
+				return msg
+			},
+		},
+		{
+			name:   "24 byte message (3 * 8-byte blocks)",
+			length: 24,
+			createMsg: func(n int) []byte {
+				msg := make([]byte, n)
+				for i := 0; i < n; i++ {
+					msg[i] = byte(i + 1)
+				}
+				return msg
+			},
+		},
+		{
+			name:   "25 byte message",
+			length: 25,
+			createMsg: func(n int) []byte {
+				msg := make([]byte, n)
+				for i := 0; i < n; i++ {
+					msg[i] = byte(i + 1)
+				}
+				return msg
+			},
+		},
+		{
+			name:   "Message ending with legitimate zero bytes",
+			length: 10,
+			createMsg: func(n int) []byte {
+				// Create a message that ends with zeros
+				// This tests that we don't mistake legitimate zeros for padding
+				return []byte{0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x00, 0x00, 0x00, 0x00}
+			},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Create sessions for wrap/unwrap
+			clientSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+			require.NoError(t, err)
+
+			serverSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, false, 0)
+			require.NoError(t, err)
+
+			// Create original message
+			original := tc.createMsg(tc.length)
+			require.Equal(t, tc.length, len(original), "test setup: message length should match")
+
+			// Wrap the message
+			wrapped, err := clientSession.Wrap(original)
+			require.NoError(t, err)
+
+			// Unwrap the message
+			unwrapped, err := serverSession.Unwrap(wrapped)
+			require.NoError(t, err)
+
+			// CRITICAL ASSERTIONS for zero residue:
+			// 1. Length must be exactly the same (no trailing padding)
+			assert.Equal(t, len(original), len(unwrapped),
+				"Unwrapped message length must equal original length (no crypto-system residue)")
+
+			// 2. Content must be byte-for-byte identical (no corruption, no padding)
+			assert.True(t, bytes.Equal(original, unwrapped),
+				"Unwrapped message must be identical to original (no crypto-system residue)")
+
+			// Additional verification: if lengths match but content differs,
+			// show exactly where they differ for debugging
+			if len(original) == len(unwrapped) && !bytes.Equal(original, unwrapped) {
+				for i := 0; i < len(original); i++ {
+					if original[i] != unwrapped[i] {
+						t.Errorf("Byte mismatch at position %d: original=0x%02x, unwrapped=0x%02x",
+							i, original[i], unwrapped[i])
+					}
+				}
+			}
+
+			// Verify EC field contains the filler size (should be 0 for AES-CTS)
+			ec := binary.BigEndian.Uint16(wrapped[4:6])
+			t.Logf("Message length: %d bytes, EC (filler size): %d bytes", tc.length, ec)
+		})
+	}
 }

--- a/v8/gssapi/securitylayer_rfc4752_test.go
+++ b/v8/gssapi/securitylayer_rfc4752_test.go
@@ -1,0 +1,361 @@
+package gssapi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"testing"
+
+	"github.com/jcmturner/gokrb5/v8/types"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// RFC 4752 and RFC 4422 SASL Compliance Tests
+// These tests verify that our implementation follows RFC 4752 (GSSAPI SASL mechanism)
+// and RFC 4422 (SASL Framework) precisely.
+
+// getTestKeyForSASL returns a test encryption key for SASL testing
+func getTestKeyForSASL() types.EncryptionKey {
+	key, _ := hex.DecodeString("14f9bde6b50ec508201a97f74c4e5bd3")
+	return types.EncryptionKey{
+		KeyType:  17, // AES128-CTS-HMAC-SHA1-96
+		KeyValue: key,
+	}
+}
+
+// TestRFC4752_SecurityLayerValues verifies security layer bit-mask values
+// Per RFC 4752 Section 3: Layer 1 = No security, 2 = Integrity, 4 = Confidentiality
+func TestRFC4752_SecurityLayerValues(t *testing.T) {
+	assert.Equal(t, SecurityLayer(1), SecurityLayerNone, "No security layer must be bit-mask 1")
+	assert.Equal(t, SecurityLayer(2), SecurityLayerIntegrity, "Integrity layer must be bit-mask 2")
+	assert.Equal(t, SecurityLayer(4), SecurityLayerConfidentiality, "Confidentiality layer must be bit-mask 4")
+}
+
+// TestRFC4752_SecurityLayerNone verifies behavior with no security layer
+// Per RFC 4752: Layer 1 provides authentication only, no wrapping
+func TestRFC4752_SecurityLayerNone(t *testing.T) {
+	key := getTestKeyForSASL()
+	session, err := NewSecurityLayerSession(key, SecurityLayerNone, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("plaintext message")
+
+	// With no security layer, message should pass through unchanged
+	wrapped, err := session.Wrap(message)
+	require.NoError(t, err)
+	assert.Equal(t, message, wrapped, "No security layer should not modify message")
+
+	unwrapped, err := session.Unwrap(wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, message, unwrapped, "Unwrap should return original message")
+}
+
+// TestRFC4752_IntegrityLayer verifies integrity protection (conf_flag=FALSE)
+// Per RFC 4752 Section 3: "the client passes the data to GSS_Wrap with conf_flag set to FALSE"
+func TestRFC4752_IntegrityLayer(t *testing.T) {
+	key := getTestKeyForSASL()
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	message := []byte("integrity protected message")
+
+	// Wrap with integrity (conf_flag=FALSE, sealed bit not set)
+	wrapped, err := clientSession.Wrap(message)
+	require.NoError(t, err)
+
+	// Verify sealed flag is NOT set (bit 1 of flags byte)
+	flags := wrapped[2]
+	sealedBit := (flags & 0x02) >> 1
+	assert.Equal(t, byte(0), sealedBit, "Integrity layer must have conf_flag=FALSE (sealed bit unset)")
+
+	// Verify message can be unwrapped
+	unwrapped, err := serverSession.Unwrap(wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, message, unwrapped)
+}
+
+// TestRFC4752_ConfidentialityLayer verifies confidentiality protection (conf_flag=TRUE)
+// Per RFC 4752 Section 3: Confidentiality layer uses GSS_Wrap with conf_flag=TRUE
+func TestRFC4752_ConfidentialityLayer(t *testing.T) {
+	key := getTestKeyForSASL()
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, false, 0)
+	require.NoError(t, err)
+
+	message := []byte("confidential message")
+
+	// Wrap with confidentiality (conf_flag=TRUE, sealed bit set)
+	wrapped, err := clientSession.Wrap(message)
+	require.NoError(t, err)
+
+	// Verify sealed flag IS set (bit 1 of flags byte)
+	flags := wrapped[2]
+	sealedBit := (flags & 0x02) >> 1
+	assert.Equal(t, byte(1), sealedBit, "Confidentiality layer must have conf_flag=TRUE (sealed bit set)")
+
+	// Verify payload is encrypted (not plaintext)
+	payload := wrapped[16:] // Skip header
+	assert.NotEqual(t, message, payload, "Payload must be encrypted with confidentiality layer")
+
+	// Verify message can be unwrapped
+	unwrapped, err := serverSession.Unwrap(wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, message, unwrapped)
+}
+
+// TestRFC4422_SASLFraming verifies SASL message framing per RFC 4422 Section 3.7
+// "Each buffer of protected data is transferred...as a sequence of octets prepended
+// with a four-octet field in network byte order that represents the length of the buffer."
+func TestRFC4422_SASLFraming(t *testing.T) {
+	key := getTestKeyForSASL()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("test message for framing")
+
+	// Wrap with SASL framing
+	framed, err := session.WrapWithSASLFraming(message)
+	require.NoError(t, err)
+
+	// Verify structure: [4-byte length][wrapped token]
+	require.GreaterOrEqual(t, len(framed), 4, "Framed message must have at least 4-byte length prefix")
+
+	// Extract and verify length field (network byte order = big-endian)
+	length := binary.BigEndian.Uint32(framed[0:4])
+	wrappedTokenSize := uint32(len(framed) - 4)
+
+	assert.Equal(t, wrappedTokenSize, length, "Length field must equal size of wrapped token (excluding length field itself)")
+
+	// Verify the wrapped token starts at byte 4
+	wrappedToken := framed[4:]
+	assert.Equal(t, int(length), len(wrappedToken), "Wrapped token size must match length field")
+
+	// Verify token has valid GSS-API WrapToken format
+	assert.Equal(t, byte(0x05), wrappedToken[0], "Wrapped token must be valid GSS-API token")
+	assert.Equal(t, byte(0x04), wrappedToken[1], "Wrapped token must be valid GSS-API token")
+}
+
+// TestRFC4422_NetworkByteOrder verifies length field uses network byte order (big-endian)
+// Per RFC 4422 Section 3.7: "four-octet field in network byte order"
+func TestRFC4422_NetworkByteOrder(t *testing.T) {
+	key := getTestKeyForSASL()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	message := []byte("test")
+	framed, err := session.WrapWithSASLFraming(message)
+	require.NoError(t, err)
+
+	// Extract length using big-endian
+	lengthBigEndian := binary.BigEndian.Uint32(framed[0:4])
+
+	// Extract length using little-endian (incorrect)
+	lengthLittleEndian := binary.LittleEndian.Uint32(framed[0:4])
+
+	// Verify they're different (unless length happens to be symmetric)
+	actualTokenSize := uint32(len(framed) - 4)
+
+	assert.Equal(t, actualTokenSize, lengthBigEndian, "Big-endian parsing must yield correct length")
+
+	// Only check this if the length isn't a symmetric value
+	if lengthBigEndian != lengthLittleEndian {
+		assert.NotEqual(t, actualTokenSize, lengthLittleEndian, "Little-endian parsing must not yield correct length")
+	}
+}
+
+// TestRFC4422_MaxBufferSize verifies maximum buffer size handling
+// Per RFC 4422 Section 3.7: "The length of the protected data buffer MUST be no larger
+// than the maximum size that the other side expects"
+func TestRFC4422_MaxBufferSize(t *testing.T) {
+	key := getTestKeyForSASL()
+
+	// Create session with max message size of 100 bytes
+	maxSize := 100
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, maxSize)
+	require.NoError(t, err)
+
+	// Message within limit should succeed
+	smallMessage := make([]byte, 50)
+	_, err = session.Wrap(smallMessage)
+	assert.NoError(t, err, "Message within limit should wrap successfully")
+
+	// Message exceeding limit should be rejected on unwrap
+	largeMessage := make([]byte, 200)
+	wrapped, err := session.Wrap(largeMessage)
+	require.NoError(t, err, "Wrap should succeed regardless of size")
+
+	// Create receiving session with same max size
+	recvSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, maxSize)
+	require.NoError(t, err)
+
+	// Unwrap should reject message exceeding max size
+	_, err = recvSession.Unwrap(wrapped)
+	assert.Error(t, err, "Unwrap should reject messages exceeding maximum size")
+	assert.Contains(t, err.Error(), "exceeds maximum", "Error should indicate size limit exceeded")
+}
+
+// TestRFC4422_SecurityLayerReplacement verifies that security layers can be replaced
+// Per RFC 4422 Section 3.7: "Protocols supporting multiple authentications cannot
+// simultaneously have multiple security layers in effect"
+func TestRFC4422_SecurityLayerReplacement(t *testing.T) {
+	key := getTestKeyForSASL()
+
+	// Start with no security layer
+	session, err := NewSecurityLayerSession(key, SecurityLayerNone, true, 0)
+	require.NoError(t, err)
+	assert.Equal(t, SecurityLayerNone, session.layer)
+
+	// "Replace" with integrity layer (create new session)
+	session, err = NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+	assert.Equal(t, SecurityLayerIntegrity, session.layer)
+
+	// "Replace" with confidentiality layer (create new session)
+	session, err = NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+	assert.Equal(t, SecurityLayerConfidentiality, session.layer)
+}
+
+// TestRFC4422_SASLFramingRoundTrip verifies complete SASL framing round-trip
+func TestRFC4422_SASLFramingRoundTrip(t *testing.T) {
+	key := getTestKeyForSASL()
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	originalMessage := []byte("SASL framed message test")
+
+	// Client wraps with SASL framing
+	framed, err := clientSession.WrapWithSASLFraming(originalMessage)
+	require.NoError(t, err)
+
+	// Server unwraps from SASL framing
+	reader := bytes.NewReader(framed)
+	unwrapped, err := serverSession.UnwrapFromSASLFraming(reader)
+	require.NoError(t, err)
+
+	assert.Equal(t, originalMessage, unwrapped, "Round-trip should preserve message")
+}
+
+// TestRFC4752_BiDirectionalCommunication verifies bidirectional wrapped communication
+// Per RFC 4752: Both client and server can send wrapped messages
+func TestRFC4752_BiDirectionalCommunication(t *testing.T) {
+	key := getTestKeyForSASL()
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	// Client to server
+	clientMsg := []byte("client request")
+	wrapped, err := clientSession.Wrap(clientMsg)
+	require.NoError(t, err)
+
+	unwrapped, err := serverSession.Unwrap(wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, clientMsg, unwrapped)
+
+	// Server to client
+	serverMsg := []byte("server response")
+	wrapped, err = serverSession.Wrap(serverMsg)
+	require.NoError(t, err)
+
+	unwrapped, err = clientSession.Unwrap(wrapped)
+	require.NoError(t, err)
+	assert.Equal(t, serverMsg, unwrapped)
+}
+
+// TestRFC4422_ZeroLengthMessage verifies handling of zero-length messages
+func TestRFC4422_ZeroLengthMessage(t *testing.T) {
+	key := getTestKeyForSASL()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	// Wrap empty message
+	emptyMessage := []byte{}
+	wrapped, err := session.Wrap(emptyMessage)
+	require.NoError(t, err)
+
+	// Should still have valid WrapToken structure with header and checksum
+	require.GreaterOrEqual(t, len(wrapped), 16, "Even empty message should have header")
+}
+
+// TestRFC4422_LengthFieldRange verifies length field can represent expected range
+func TestRFC4422_LengthFieldRange(t *testing.T) {
+	// 4-byte unsigned integer can represent 0 to 4,294,967,295
+	// Our implementation limits to 16MB (1<<24 = 16,777,216)
+
+	tests := []struct {
+		name        string
+		length      uint32
+		shouldError bool
+	}{
+		{"Zero length", 0, true},
+		{"Small message", 100, false},
+		{"1KB message", 1024, false},
+		{"1MB message", 1 << 20, false},
+		{"16MB message", 1 << 24, false},
+		{"Over 16MB", (1 << 24) + 1, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// Create a simulated SASL frame with the given length
+			frame := make([]byte, 4)
+			binary.BigEndian.PutUint32(frame, tt.length)
+
+			key := getTestKeyForSASL()
+			session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+			require.NoError(t, err)
+
+			// Try to read from this frame
+			// We expect an error if length is 0 or > 16MB
+			reader := bytes.NewReader(frame)
+			_, err = session.UnwrapFromSASLFraming(reader)
+
+			if tt.shouldError {
+				assert.Error(t, err, "Should reject invalid length")
+			}
+			// Note: For valid lengths, we'll get an EOF error because there's no actual data
+			// That's expected for this test
+		})
+	}
+}
+
+// TestRFC4752_GSS_Wrap_Documentation verifies our implementation matches RFC 4752 description
+// This is a documentation test to ensure our understanding is correct
+func TestRFC4752_GSS_Wrap_Documentation(t *testing.T) {
+	// RFC 4752 states:
+	// - Integrity: GSS_Wrap with conf_flag=FALSE
+	// - Confidentiality: GSS_Wrap with conf_flag=TRUE
+
+	// Our implementation:
+	// - Integrity: Sealed flag (bit 1) = 0
+	// - Confidentiality: Sealed flag (bit 1) = 1
+
+	// This test documents that our sealed flag maps to GSS-API conf_flag
+	key := getTestKeyForSASL()
+
+	// Verify integrity mapping
+	integritySession, _ := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	integrityWrapped, _ := integritySession.Wrap([]byte("test"))
+	integrityFlags := integrityWrapped[2]
+	confFlagIntegrity := (integrityFlags & 0x02) != 0
+	assert.False(t, confFlagIntegrity, "Integrity layer: conf_flag (sealed bit) should be FALSE")
+
+	// Verify confidentiality mapping
+	confSession, _ := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	confWrapped, _ := confSession.Wrap([]byte("test"))
+	confFlags := confWrapped[2]
+	confFlagConf := (confFlags & 0x02) != 0
+	assert.True(t, confFlagConf, "Confidentiality layer: conf_flag (sealed bit) should be TRUE")
+}

--- a/v8/gssapi/securitylayer_test.go
+++ b/v8/gssapi/securitylayer_test.go
@@ -1,0 +1,560 @@
+package gssapi
+
+import (
+	"bytes"
+	"encoding/binary"
+	"encoding/hex"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/jcmturner/gokrb5/v8/types"
+)
+
+// Test session key (from wrapToken_test.go)
+const (
+	testSessionKey     = "14f9bde6b50ec508201a97f74c4e5bd3"
+	testSessionKeyType = 17 // AES128-CTS-HMAC-SHA1-96
+)
+
+func getTestSessionKey() types.EncryptionKey {
+	key, _ := hex.DecodeString(testSessionKey)
+	return types.EncryptionKey{
+		KeyType:  testSessionKeyType,
+		KeyValue: key,
+	}
+}
+
+func TestNewSecurityLayerSession(t *testing.T) {
+	key := getTestSessionKey()
+
+	tests := []struct {
+		name        string
+		layer       SecurityLayer
+		isInitiator bool
+		maxMsgSize  int
+		shouldError bool
+	}{
+		{"None layer", SecurityLayerNone, true, 0, false},
+		{"Integrity layer", SecurityLayerIntegrity, true, 0, false},
+		{"Confidentiality layer", SecurityLayerConfidentiality, true, 0, false},
+		{"With max message size", SecurityLayerIntegrity, true, 1024, false},
+		{"Invalid layer", SecurityLayer(99), true, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			session, err := NewSecurityLayerSession(key, tt.layer, tt.isInitiator, tt.maxMsgSize)
+			if tt.shouldError {
+				assert.Error(t, err)
+				assert.Nil(t, session)
+			} else {
+				assert.NoError(t, err)
+				assert.NotNil(t, session)
+				assert.Equal(t, tt.layer, session.layer)
+				assert.Equal(t, tt.isInitiator, session.isInitiator)
+				assert.Equal(t, tt.maxMsgSize, session.maxMessageSize)
+				assert.Equal(t, uint64(0), session.sendSeqNum)
+				assert.Equal(t, uint64(0), session.recvSeqNum)
+			}
+		})
+	}
+}
+
+func TestSecurityLayerSession_WrapUnwrap_None(t *testing.T) {
+	key := getTestSessionKey()
+	message := []byte("Hello, SASL!")
+
+	// Create sessions for both sides
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerNone, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerNone, false, 0)
+	require.NoError(t, err)
+
+	// Wrap from client
+	wrapped, err := clientSession.Wrap(message)
+	assert.NoError(t, err)
+	assert.Equal(t, message, wrapped) // No wrapping for SecurityLayerNone
+
+	// Unwrap on server
+	unwrapped, err := serverSession.Unwrap(wrapped)
+	assert.NoError(t, err)
+	assert.Equal(t, message, unwrapped)
+}
+
+func TestSecurityLayerSession_WrapUnwrap_Integrity(t *testing.T) {
+	key := getTestSessionKey()
+	message := []byte("Hello, SASL with integrity!")
+
+	// Create sessions for both sides
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	// Wrap from client
+	wrapped, err := clientSession.Wrap(message)
+	assert.NoError(t, err)
+	assert.NotEqual(t, message, wrapped) // Should be wrapped
+	assert.Greater(t, len(wrapped), len(message)) // Wrapped should be larger
+
+	// Verify it's a valid GSS-API token
+	assert.Equal(t, byte(0x05), wrapped[0])
+	assert.Equal(t, byte(0x04), wrapped[1])
+
+	// Unwrap on server
+	unwrapped, err := serverSession.Unwrap(wrapped)
+	assert.NoError(t, err)
+	assert.Equal(t, message, unwrapped)
+}
+
+func TestSecurityLayerSession_WrapUnwrap_Confidentiality(t *testing.T) {
+	key := getTestSessionKey()
+	message := []byte("Hello, SASL with confidentiality!")
+
+	// Create sessions for both sides
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, false, 0)
+	require.NoError(t, err)
+
+	// Wrap from client
+	wrapped, err := clientSession.Wrap(message)
+	assert.NoError(t, err)
+	assert.NotEqual(t, message, wrapped) // Should be wrapped
+	assert.Greater(t, len(wrapped), len(message)) // Wrapped should be larger
+
+	// Verify it's a valid GSS-API token
+	assert.Equal(t, byte(0x05), wrapped[0])
+	assert.Equal(t, byte(0x04), wrapped[1])
+
+	// Verify sealed flag is set
+	assert.Equal(t, byte(0x02), wrapped[2]&0x02, "sealed flag should be set")
+
+	// Verify payload is encrypted (should not contain plaintext)
+	assert.NotContains(t, string(wrapped), string(message), "plaintext should not be visible in wrapped message")
+
+	// Unwrap on server
+	unwrapped, err := serverSession.Unwrap(wrapped)
+	assert.NoError(t, err)
+	assert.Equal(t, message, unwrapped)
+}
+
+func TestSecurityLayerSession_Confidentiality_MultipleMessages(t *testing.T) {
+	key := getTestSessionKey()
+
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerConfidentiality, false, 0)
+	require.NoError(t, err)
+
+	messages := []string{
+		"First encrypted message",
+		"Second encrypted message",
+		"Third encrypted message",
+	}
+
+	for i, msg := range messages {
+		wrapped, err := clientSession.Wrap([]byte(msg))
+		assert.NoError(t, err)
+
+		// Verify sequence number increments
+		var token WrapToken
+		err = token.Unmarshal(wrapped, false)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(i), token.SndSeqNum)
+
+		// Verify sealed flag is set
+		assert.Equal(t, byte(0x02), token.Flags&0x02, "sealed flag should be set")
+
+		unwrapped, err := serverSession.Unwrap(wrapped)
+		assert.NoError(t, err)
+		assert.Equal(t, msg, string(unwrapped))
+	}
+}
+
+func TestSecurityLayerSession_WrapUnwrap_MultipleMessages(t *testing.T) {
+	key := getTestSessionKey()
+
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	messages := []string{
+		"First message",
+		"Second message",
+		"Third message",
+	}
+
+	for i, msg := range messages {
+		wrapped, err := clientSession.Wrap([]byte(msg))
+		assert.NoError(t, err)
+
+		// Verify sequence number increments
+		var token WrapToken
+		err = token.Unmarshal(wrapped, false)
+		assert.NoError(t, err)
+		assert.Equal(t, uint64(i), token.SndSeqNum)
+
+		unwrapped, err := serverSession.Unwrap(wrapped)
+		assert.NoError(t, err)
+		assert.Equal(t, msg, string(unwrapped))
+	}
+}
+
+func TestSecurityLayerSession_SequenceNumberValidation(t *testing.T) {
+	key := getTestSessionKey()
+
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	// Wrap two messages
+	msg1 := []byte("Message 1")
+	msg2 := []byte("Message 2")
+
+	wrapped1, err := clientSession.Wrap(msg1)
+	require.NoError(t, err)
+	wrapped2, err := clientSession.Wrap(msg2)
+	require.NoError(t, err)
+
+	// Receive in order - should work
+	_, err = serverSession.Unwrap(wrapped1)
+	assert.NoError(t, err)
+	_, err = serverSession.Unwrap(wrapped2)
+	assert.NoError(t, err)
+
+	// Try to replay message 1 - should fail
+	_, err = serverSession.Unwrap(wrapped1)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "sequence number out of order")
+}
+
+func TestSecurityLayerSession_MaxMessageSize(t *testing.T) {
+	key := getTestSessionKey()
+	maxSize := 10
+
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, maxSize)
+	require.NoError(t, err)
+
+	// Message within limit
+	smallMsg := []byte("Small")
+	wrapped, err := clientSession.Wrap(smallMsg)
+	require.NoError(t, err)
+	unwrapped, err := serverSession.Unwrap(wrapped)
+	assert.NoError(t, err)
+	assert.Equal(t, smallMsg, unwrapped)
+
+	// Message exceeding limit
+	largeMsg := []byte("This is a very large message")
+	wrapped, err = clientSession.Wrap(largeMsg)
+	require.NoError(t, err)
+	_, err = serverSession.Unwrap(wrapped)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "exceeds maximum")
+}
+
+func TestSecurityLayerSession_WrapWithSASLFraming(t *testing.T) {
+	key := getTestSessionKey()
+	message := []byte("Test message")
+
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	framed, err := session.WrapWithSASLFraming(message)
+	assert.NoError(t, err)
+
+	// Should have 4-byte length prefix
+	assert.GreaterOrEqual(t, len(framed), 4)
+
+	// Extract length
+	length := binary.BigEndian.Uint32(framed[0:4])
+	assert.Equal(t, uint32(len(framed)-4), length)
+
+	// Verify token starts after length
+	assert.Equal(t, byte(0x05), framed[4])
+	assert.Equal(t, byte(0x04), framed[5])
+}
+
+func TestSecurityLayerSession_UnwrapFromSASLFraming(t *testing.T) {
+	key := getTestSessionKey()
+	message := []byte("Test message for SASL framing")
+
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	// Wrap with framing
+	framed, err := clientSession.WrapWithSASLFraming(message)
+	require.NoError(t, err)
+
+	// Create a reader from the framed bytes
+	reader := bytes.NewReader(framed)
+
+	// Unwrap from framing
+	unwrapped, err := serverSession.UnwrapFromSASLFraming(reader)
+	assert.NoError(t, err)
+	assert.Equal(t, message, unwrapped)
+}
+
+func TestSecurityLayerSession_UnwrapFromSASLFraming_Errors(t *testing.T) {
+	key := getTestSessionKey()
+
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	tests := []struct {
+		name        string
+		data        []byte
+		expectError string
+	}{
+		{
+			name:        "Empty data",
+			data:        []byte{},
+			expectError: "failed to read SASL frame length",
+		},
+		{
+			name:        "Incomplete length header",
+			data:        []byte{0x00, 0x00},
+			expectError: "failed to read SASL frame length",
+		},
+		{
+			name:        "Zero length",
+			data:        []byte{0x00, 0x00, 0x00, 0x00},
+			expectError: "invalid SASL frame length: 0",
+		},
+		{
+			name:        "Length too large",
+			data:        []byte{0x7F, 0xFF, 0xFF, 0xFF}, // 2GB
+			expectError: "SASL frame length too large",
+		},
+		{
+			name:        "Incomplete message",
+			data:        []byte{0x00, 0x00, 0x00, 0x10, 0x05, 0x04}, // Says 16 bytes but only 2
+			expectError: "failed to read wrapped message",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			reader := bytes.NewReader(tt.data)
+			_, err := session.UnwrapFromSASLFraming(reader)
+			assert.Error(t, err)
+			assert.Contains(t, err.Error(), tt.expectError)
+		})
+	}
+}
+
+// mockConn is a mock net.Conn implementation for testing
+type mockConn struct {
+	readBuf  *bytes.Buffer
+	writeBuf *bytes.Buffer
+	closed   bool
+}
+
+func newMockConn() *mockConn {
+	return &mockConn{
+		readBuf:  new(bytes.Buffer),
+		writeBuf: new(bytes.Buffer),
+	}
+}
+
+func (m *mockConn) Read(b []byte) (n int, err error) {
+	if m.closed {
+		return 0, io.EOF
+	}
+	return m.readBuf.Read(b)
+}
+
+func (m *mockConn) Write(b []byte) (n int, err error) {
+	if m.closed {
+		return 0, io.ErrClosedPipe
+	}
+	return m.writeBuf.Write(b)
+}
+
+func (m *mockConn) Close() error {
+	m.closed = true
+	return nil
+}
+
+func (m *mockConn) LocalAddr() net.Addr                { return nil }
+func (m *mockConn) RemoteAddr() net.Addr               { return nil }
+func (m *mockConn) SetDeadline(t time.Time) error      { return nil }
+func (m *mockConn) SetReadDeadline(t time.Time) error  { return nil }
+func (m *mockConn) SetWriteDeadline(t time.Time) error { return nil }
+
+func TestSecureConn_Write(t *testing.T) {
+	key := getTestSessionKey()
+	message := []byte("Test message for SecureConn")
+
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	mockConn := newMockConn()
+	secureConn := NewSecureConn(mockConn, session)
+
+	// Write should wrap and frame the message
+	n, err := secureConn.Write(message)
+	assert.NoError(t, err)
+	assert.Equal(t, len(message), n) // Should return original message length
+
+	// Check that data was written to underlying connection
+	written := mockConn.writeBuf.Bytes()
+	assert.Greater(t, len(written), len(message)) // Should be wrapped
+
+	// Verify SASL framing
+	length := binary.BigEndian.Uint32(written[0:4])
+	assert.Equal(t, uint32(len(written)-4), length)
+
+	// Verify GSS-API token
+	assert.Equal(t, byte(0x05), written[4])
+	assert.Equal(t, byte(0x04), written[5])
+}
+
+func TestSecureConn_Read(t *testing.T) {
+	key := getTestSessionKey()
+	message := []byte("Test message for SecureConn read")
+
+	// Create client and server sessions
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	// Wrap message as client
+	framedMessage, err := clientSession.WrapWithSASLFraming(message)
+	require.NoError(t, err)
+
+	// Set up mock connection with the framed message
+	mockConn := newMockConn()
+	mockConn.readBuf.Write(framedMessage)
+
+	secureConn := NewSecureConn(mockConn, serverSession)
+
+	// Read should unwrap the message
+	buf := make([]byte, 1024)
+	n, err := secureConn.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, len(message), n)
+	assert.Equal(t, message, buf[:n])
+}
+
+func TestSecureConn_Read_PartialBuffer(t *testing.T) {
+	key := getTestSessionKey()
+	message := []byte("This is a longer test message for SecureConn")
+
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	// Wrap message
+	framedMessage, err := clientSession.WrapWithSASLFraming(message)
+	require.NoError(t, err)
+
+	// Set up mock connection
+	mockConn := newMockConn()
+	mockConn.readBuf.Write(framedMessage)
+
+	secureConn := NewSecureConn(mockConn, serverSession)
+
+	// Read with small buffer - should require multiple reads
+	smallBuf := make([]byte, 10)
+	var received []byte
+
+	for len(received) < len(message) {
+		n, err := secureConn.Read(smallBuf)
+		if err != nil {
+			if err == io.EOF {
+				break
+			}
+			t.Fatalf("Unexpected error: %v", err)
+		}
+		received = append(received, smallBuf[:n]...)
+	}
+
+	assert.Equal(t, message, received)
+}
+
+func TestSecureConn_RoundTrip(t *testing.T) {
+	key := getTestSessionKey()
+
+	// Create client and server sessions
+	clientSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	serverSession, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, false, 0)
+	require.NoError(t, err)
+
+	// Create mock connections (each side's write goes to other side's read)
+	clientWriteConn := newMockConn()
+	serverWriteConn := newMockConn()
+
+	// Create a bidirectional setup
+	clientConn := &mockConn{
+		writeBuf: clientWriteConn.writeBuf,
+		readBuf:  serverWriteConn.writeBuf,
+	}
+	serverConn := &mockConn{
+		writeBuf: serverWriteConn.writeBuf,
+		readBuf:  clientWriteConn.writeBuf,
+	}
+
+	secureClient := NewSecureConn(clientConn, clientSession)
+	secureServer := NewSecureConn(serverConn, serverSession)
+
+	// Client sends to server
+	clientMsg := []byte("Hello from client")
+	n, err := secureClient.Write(clientMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, len(clientMsg), n)
+
+	// Server receives from client
+	buf := make([]byte, 1024)
+	n, err = secureServer.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, clientMsg, buf[:n])
+
+	// Server replies to client
+	serverMsg := []byte("Hello from server")
+	n, err = secureServer.Write(serverMsg)
+	assert.NoError(t, err)
+	assert.Equal(t, len(serverMsg), n)
+
+	// Client receives from server
+	n, err = secureClient.Read(buf)
+	assert.NoError(t, err)
+	assert.Equal(t, serverMsg, buf[:n])
+}
+
+func TestSecureConn_Close(t *testing.T) {
+	key := getTestSessionKey()
+	session, err := NewSecurityLayerSession(key, SecurityLayerIntegrity, true, 0)
+	require.NoError(t, err)
+
+	mockConn := newMockConn()
+	secureConn := NewSecureConn(mockConn, session)
+
+	err = secureConn.Close()
+	assert.NoError(t, err)
+	assert.True(t, mockConn.closed)
+}

--- a/v8/gssapi/wrapToken.go
+++ b/v8/gssapi/wrapToken.go
@@ -110,6 +110,13 @@ func getChecksumHeader(flags byte, senderSeqNum uint64) []byte {
 	return header
 }
 
+// GetEmbeddedHeader returns the 16-byte header with EC and RRC fields zeroed.
+// This is used for encryption (RFC 4121 section 4.2.4) and checksum computation,
+// where the embedded header must have EC=0 and RRC=0.
+func (wt *WrapToken) GetEmbeddedHeader() []byte {
+	return getChecksumHeader(wt.Flags, wt.SndSeqNum)
+}
+
 // Verify computes the token's checksum with the provided key and usage,
 // and compares it to the checksum present in the token.
 // In case of any failure, (false, Err) is returned, with Err an explanatory error.


### PR DESCRIPTION
## What this does

Implements SASL security layers (RFC 4752) for GSSAPI/Kerberos authentication
providing message integrity protection and confidentiality after authentication.

Follows RFC 4121 (GSS-API v2 WrapToken format), RFC 4752 (GSSAPI SASL mechanism),
and RFC 4422 (SASL framing with 4-byte length prefix).

Tested against Windows Active Directory (LDAP on port 389).

Fixes #567
 
## Impact

This adds new APIs -- requires a minor version bump

## Implementation

Three new components in `v8/gssapi`:

**SecurityLayerSession** - Session management for message wrapping/unwrapping:

```go
session, err := gssapi.NewSecurityLayerSession(sessionKey, gssapi.SecurityLayerIntegrity, true, 65536)
wrapped, err := session.Wrap(message)
unwrapped, err := session.Unwrap(wrapped)
```

**SASL Framing** - RFC 4422 framing with 4-byte length prefix:

```go
framedMessage, err := session.WrapWithSASLFraming(message)
unwrapped, err := session.UnwrapFromSASLFraming(data)
```

**SecureConn** - Transparent `net.Conn` wrapper:

```go
secureConn := gssapi.NewSecureConn(conn, session)
// All Read/Write operations automatically protected
```

## Testing

**Production tested** against Windows Active Directory:

- Integrity layer (RRC=12) ✅
- Confidentiality layer (RRC=28) ✅
- LDAP search operations ✅

## Compatibility

No breaking changes - all new exports:

- `SecurityLayer` (type)
- `SecurityLayerSession` (type)
- `SecureConn` (type)
- `NewSecurityLayerSession()` (function)
- `NewSecureConn()` (function)

Platform agnostic, zero external dependencies, targets v8 only.

## Related issues

- go-ldap/ldap#552
- #247

**Builds on:**

- #87 (this adds the high-level API)

**Note:** This implements RFC 4121 (modern GSS-API v2). For RFC 1964 (legacy), see #460.
