### PR TITLE
Feature: AutoPAFXFAST option

### DIFF
--- a/v8/USAGE.md
+++ b/v8/USAGE.md
@@ -45,13 +45,12 @@ cl.Destroy()
 ```
 
 #### Active Directory KDC and FAST negotiation
-Active Directory does not commonly support FAST negotiation so you will need to disable this on the client.
-If this is the case you will see this error:
+By default the client automatically attempts FAST negotiation first and, if the KDC does not support it, retries once without FAST.
+If FAST negotiation is not supported you may see this error before the automatic retry occurs:
 ```KDC did not respond appropriately to FAST negotiation```
-To resolve this disable PA-FX-Fast on the client before performing Login().
-This is done with one of the optional client settings as shown below:
+If you want to disable this automatic behavior and force FAST off, set both options as shown below:
 ```go
-cl := client.NewWithPassword("username", "REALM.COM", "password", cfg, client.DisablePAFXFAST(true))
+cl := client.NewWithPassword("username", "REALM.COM", "password", cfg, client.AutoPAFXFAST(false), client.DisablePAFXFAST(true))
 ```
 
 #### Authenticate to a Service

--- a/v8/client/ASExchange.go
+++ b/v8/client/ASExchange.go
@@ -17,8 +17,23 @@ func (cl *Client) ASExchange(realm string, ASReq messages.ASReq, referral int) (
 		return messages.ASRep{}, krberror.Errorf(err, krberror.ConfigError, "AS Exchange cannot be performed")
 	}
 
+	usePAFXFAST := cl.usePAFXFASTOnInitialASExchangeAttempt()
+	ASRep, err := cl.asExchangeAttempt(realm, ASReq, referral, usePAFXFAST)
+	if err == nil {
+		return ASRep, nil
+	}
+
+	if !cl.shouldRetryASExchangeWithoutPAFXFAST(usePAFXFAST, err) {
+		return messages.ASRep{}, err
+	}
+
+	cl.Log("AS Exchange Error: KDC did not support PA_FX_FAST negotiation; retrying AS exchange without PA_FX_FAST")
+	return cl.asExchangeAttempt(realm, ASReq, referral, false)
+}
+
+func (cl *Client) asExchangeAttempt(realm string, ASReq messages.ASReq, referral int, usePAFXFAST bool) (messages.ASRep, error) {
 	// Set PAData if required
-	err := setPAData(cl, nil, &ASReq)
+	err := setPAData(cl, nil, &ASReq, usePAFXFAST)
 	if err != nil {
 		return messages.ASRep{}, krberror.Errorf(err, krberror.KRBMsgError, "AS Exchange Error: issue with setting PAData on AS_REQ")
 	}
@@ -36,7 +51,7 @@ func (cl *Client) ASExchange(realm string, ASReq messages.ASReq, referral int) (
 			case errorcode.KDC_ERR_PREAUTH_REQUIRED, errorcode.KDC_ERR_PREAUTH_FAILED:
 				// From now on assume this client will need to do this pre-auth and set the PAData
 				cl.settings.assumePreAuthentication = true
-				err = setPAData(cl, &e, &ASReq)
+				err = setPAData(cl, &e, &ASReq, usePAFXFAST)
 				if err != nil {
 					return messages.ASRep{}, krberror.Errorf(err, krberror.KRBMsgError, "AS Exchange Error: failed setting AS_REQ PAData for pre-authentication required")
 				}
@@ -75,9 +90,30 @@ func (cl *Client) ASExchange(realm string, ASReq messages.ASReq, referral int) (
 	return ASRep, nil
 }
 
+func (cl *Client) usePAFXFASTOnInitialASExchangeAttempt() bool {
+	if cl.settings.AutoPAFXFAST() {
+		return true
+	}
+	return !cl.settings.DisablePAFXFAST()
+}
+
+func (cl *Client) shouldRetryASExchangeWithoutPAFXFAST(usePAFXFAST bool, err error) bool {
+	return cl.settings.AutoPAFXFAST() && usePAFXFAST && isPAFXFASTUnsupportedError(err)
+}
+
+func isPAFXFASTUnsupportedError(err error) bool {
+	e, ok := err.(krberror.Krberror)
+	if !ok {
+		return false
+	}
+	return e.RootCause == krberror.PAFXFASTUnsupportedError
+}
+
 // setPAData adds pre-authentication data to the AS_REQ.
-func setPAData(cl *Client, krberr *messages.KRBError, ASReq *messages.ASReq) error {
-	if !cl.settings.DisablePAFXFAST() {
+func setPAData(cl *Client, krberr *messages.KRBError, ASReq *messages.ASReq, usePAFXFAST bool) error {
+	// Remove any existing PAData of type PA_REQ_ENC_PA_REP from the previous attempt if any.
+	ASReq.PAData = removePADataType(ASReq.PAData, patype.PA_REQ_ENC_PA_REP)
+	if usePAFXFAST {
 		pa := types.PAData{PADataType: patype.PA_REQ_ENC_PA_REP}
 		ASReq.PAData = append(ASReq.PAData, pa)
 	}
@@ -132,15 +168,23 @@ func setPAData(cl *Client, krberr *messages.KRBError, ASReq *messages.ASReq) err
 			PADataValue: pb,
 		}
 		// Look for and delete any exiting patype.PA_ENC_TIMESTAMP
-		for i, pa := range ASReq.PAData {
-			if pa.PADataType == patype.PA_ENC_TIMESTAMP {
-				ASReq.PAData[i] = ASReq.PAData[len(ASReq.PAData)-1]
-				ASReq.PAData = ASReq.PAData[:len(ASReq.PAData)-1]
-			}
-		}
+		ASReq.PAData = removePADataType(ASReq.PAData, patype.PA_ENC_TIMESTAMP)
 		ASReq.PAData = append(ASReq.PAData, pa)
 	}
 	return nil
+}
+
+func removePADataType(pas types.PADataSequence, paType int32) types.PADataSequence {
+	i := 0
+	for i < len(pas) {
+		if pas[i].PADataType == paType {
+			pas[i] = pas[len(pas)-1]
+			pas = pas[:len(pas)-1]
+			continue
+		}
+		i++
+	}
+	return pas
 }
 
 // preAuthEType establishes what encryption type to use for pre-authentication from the KRBError returned from the KDC.

--- a/v8/client/ASExchange_test.go
+++ b/v8/client/ASExchange_test.go
@@ -1,0 +1,190 @@
+package client
+
+import (
+	"testing"
+
+	"github.com/jcmturner/gokrb5/v8/config"
+	"github.com/jcmturner/gokrb5/v8/iana/patype"
+	"github.com/jcmturner/gokrb5/v8/keytab"
+	"github.com/jcmturner/gokrb5/v8/krberror"
+	"github.com/jcmturner/gokrb5/v8/messages"
+	"github.com/jcmturner/gokrb5/v8/types"
+)
+
+func TestSetPADataPAFXFASTToggle(t *testing.T) {
+	t.Parallel()
+
+	cl := NewWithKeytab("username", "REALM", &keytab.Keytab{}, &config.Config{})
+	asReq := messages.ASReq{
+		KDCReqFields: messages.KDCReqFields{
+			PAData: types.PADataSequence{{PADataType: patype.PA_REQ_ENC_PA_REP}},
+		},
+	}
+
+	err := setPAData(cl, nil, &asReq, true)
+	if err != nil {
+		t.Fatalf("setPAData returned error: %v", err)
+	}
+	if got := countPADataType(asReq.PAData, patype.PA_REQ_ENC_PA_REP); got != 1 {
+		t.Fatalf("expected exactly one PA_REQ_ENC_PA_REP entry, got %d", got)
+	}
+
+	err = setPAData(cl, nil, &asReq, true)
+	if err != nil {
+		t.Fatalf("setPAData returned error: %v", err)
+	}
+	if got := countPADataType(asReq.PAData, patype.PA_REQ_ENC_PA_REP); got != 1 {
+		t.Fatalf("expected exactly one PA_REQ_ENC_PA_REP entry after repeat call, got %d", got)
+	}
+
+	err = setPAData(cl, nil, &asReq, false)
+	if err != nil {
+		t.Fatalf("setPAData returned error: %v", err)
+	}
+	if got := countPADataType(asReq.PAData, patype.PA_REQ_ENC_PA_REP); got != 0 {
+		t.Fatalf("expected no PA_REQ_ENC_PA_REP entries when disabled, got %d", got)
+	}
+}
+
+func countPADataType(pas types.PADataSequence, paType int32) int {
+	count := 0
+	for _, pa := range pas {
+		if pa.PADataType == paType {
+			count++
+		}
+	}
+	return count
+}
+
+func TestShouldRetryASExchangeWithoutPAFXFAST(t *testing.T) {
+	t.Parallel()
+
+	unsupported := krberror.NewErrorf(krberror.PAFXFASTUnsupportedError, "KDC did not respond appropriately to FAST negotiation")
+	nonUnsupported := krberror.NewErrorf(krberror.KRBMsgError, "some other AS_REP verification failure")
+
+	tests := []struct {
+		name         string
+		autoPAFXFAST bool
+		usePAFXFAST  bool
+		err          error
+		expect       bool
+	}{
+		{
+			name:         "auto enabled and unsupported fast retries",
+			autoPAFXFAST: true,
+			usePAFXFAST:  true,
+			err:          unsupported,
+			expect:       true,
+		},
+		{
+			name:         "auto disabled does not retry",
+			autoPAFXFAST: false,
+			usePAFXFAST:  true,
+			err:          unsupported,
+			expect:       false,
+		},
+		{
+			name:         "fast not used does not retry",
+			autoPAFXFAST: true,
+			usePAFXFAST:  false,
+			err:          unsupported,
+			expect:       false,
+		},
+		{
+			name:         "other errors do not retry",
+			autoPAFXFAST: true,
+			usePAFXFAST:  true,
+			err:          nonUnsupported,
+			expect:       false,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			cl := NewWithKeytab("username", "REALM", &keytab.Keytab{}, &config.Config{}, AutoPAFXFAST(tc.autoPAFXFAST))
+			got := cl.shouldRetryASExchangeWithoutPAFXFAST(tc.usePAFXFAST, tc.err)
+			if got != tc.expect {
+				t.Fatalf("expected retry=%t, got %t", tc.expect, got)
+			}
+		})
+	}
+}
+
+func TestRemovePADataType(t *testing.T) {
+	t.Parallel()
+
+	const keepType int32 = patype.PA_ENC_TIMESTAMP
+	const removeType int32 = patype.PA_REQ_ENC_PA_REP
+
+	tests := []struct {
+		name       string
+		in         types.PADataSequence
+		removeType int32
+		wantCount  int
+		wantNoType bool
+	}{
+		{
+			name:       "empty sequence",
+			in:         types.PADataSequence{},
+			removeType: removeType,
+			wantCount:  0,
+			wantNoType: true,
+		},
+		{
+			name: "type absent unchanged",
+			in: types.PADataSequence{
+				{PADataType: keepType},
+				{PADataType: patype.PA_ETYPE_INFO},
+			},
+			removeType: removeType,
+			wantCount:  2,
+			wantNoType: true,
+		},
+		{
+			name: "single matching type removed",
+			in: types.PADataSequence{
+				{PADataType: keepType},
+				{PADataType: removeType},
+			},
+			removeType: removeType,
+			wantCount:  1,
+			wantNoType: true,
+		},
+		{
+			name: "multiple matching types removed",
+			in: types.PADataSequence{
+				{PADataType: removeType},
+				{PADataType: keepType},
+				{PADataType: removeType},
+				{PADataType: patype.PA_ETYPE_INFO2},
+				{PADataType: removeType},
+			},
+			removeType: removeType,
+			wantCount:  2,
+			wantNoType: true,
+		},
+	}
+
+	for _, tc := range tests {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			t.Parallel()
+			out := removePADataType(tc.in, tc.removeType)
+			if len(out) != tc.wantCount {
+				t.Fatalf("expected count=%d, got %d", tc.wantCount, len(out))
+			}
+			hasType := false
+			for _, pa := range out {
+				if pa.PADataType == tc.removeType {
+					hasType = true
+					break
+				}
+			}
+			if tc.wantNoType && hasType {
+				t.Fatalf("expected removed type %d to be absent", tc.removeType)
+			}
+		})
+	}
+}

--- a/v8/client/TGSExchange.go
+++ b/v8/client/TGSExchange.go
@@ -1,6 +1,8 @@
 package client
 
 import (
+	"fmt"
+
 	"github.com/jcmturner/gokrb5/v8/iana/flags"
 	"github.com/jcmturner/gokrb5/v8/iana/nametype"
 	"github.com/jcmturner/gokrb5/v8/krberror"
@@ -21,6 +23,14 @@ func (cl *Client) TGSREQGenerateAndExchange(spn types.PrincipalName, kdcRealm st
 // Referrals are automatically handled.
 // The client's cache is updated with the ticket received.
 func (cl *Client) TGSExchange(tgsReq messages.TGSReq, kdcRealm string, tgt messages.Ticket, sessionKey types.EncryptionKey, referral int) (messages.TGSReq, messages.TGSRep, error) {
+	return cl.tgsExchange(tgsReq, kdcRealm, tgt, sessionKey, referral, true)
+}
+
+func (cl *Client) TGSExchangeNoCache(tgsReq messages.TGSReq, kdcRealm string, tgt messages.Ticket, sessionKey types.EncryptionKey, referral int) (messages.TGSReq, messages.TGSRep, error) {
+	return cl.tgsExchange(tgsReq, kdcRealm, tgt, sessionKey, referral, false)
+}
+
+func (cl *Client) tgsExchange(tgsReq messages.TGSReq, kdcRealm string, tgt messages.Ticket, sessionKey types.EncryptionKey, referral int, cacheTicket bool) (messages.TGSReq, messages.TGSRep, error) {
 	var tgsRep messages.TGSRep
 	b, err := tgsReq.Marshal()
 	if err != nil {
@@ -66,15 +76,17 @@ func (cl *Client) TGSExchange(tgsReq messages.TGSReq, kdcRealm string, tgt messa
 		}
 		return cl.TGSExchange(tgsReq, realm, tgsRep.Ticket, tgsRep.DecryptedEncPart.Key, referral)
 	}
-	cl.cache.addEntry(
-		tgsRep.Ticket,
-		tgsRep.DecryptedEncPart.AuthTime,
-		tgsRep.DecryptedEncPart.StartTime,
-		tgsRep.DecryptedEncPart.EndTime,
-		tgsRep.DecryptedEncPart.RenewTill,
-		tgsRep.DecryptedEncPart.Key,
-	)
-	cl.Log("ticket added to cache for %s (EndTime: %v)", tgsRep.Ticket.SName.PrincipalNameString(), tgsRep.DecryptedEncPart.EndTime)
+	if cacheTicket {
+		cl.cache.addEntry(
+			tgsRep.Ticket,
+			tgsRep.DecryptedEncPart.AuthTime,
+			tgsRep.DecryptedEncPart.StartTime,
+			tgsRep.DecryptedEncPart.EndTime,
+			tgsRep.DecryptedEncPart.RenewTill,
+			tgsRep.DecryptedEncPart.Key,
+		)
+		cl.Log("ticket added to cache for %s (EndTime: %v)", tgsRep.Ticket.SName.PrincipalNameString(), tgsRep.DecryptedEncPart.EndTime)
+	}
 	return tgsReq, tgsRep, err
 }
 
@@ -103,6 +115,48 @@ func (cl *Client) GetServiceTicket(spn string) (messages.Ticket, types.Encryptio
 	_, tgsRep, err := cl.TGSREQGenerateAndExchange(princ, realm, tgt, skey, false)
 	if err != nil {
 		return tkt, skey, err
+	}
+	return tgsRep.Ticket, tgsRep.DecryptedEncPart.Key, nil
+}
+
+// GetProxyTicket uses the MS S4U2Proxy protocol extensions to request a ticket for a service
+// on behalf of another user. The proxy tickets are not looked up in or added to the ticket cache.
+// The userTicket must be a (already decrypted) forwardable ticket received from the user.
+func (cl *Client) GetProxyTicket(spn string, userTicket messages.Ticket) (messages.Ticket, types.EncryptionKey, error) {
+	var tkt messages.Ticket
+	var skey types.EncryptionKey
+
+	// The userTicket must have the forwardable field set.
+	if !types.IsFlagSet(&userTicket.DecryptedEncPart.Flags, flags.Forwardable) {
+		return tkt, skey, krberror.New(krberror.KRBMsgError, "user ticket does not have the forwardable flag set")
+	}
+
+	princ := types.NewPrincipalName(nametype.KRB_NT_PRINCIPAL, spn)
+	realm := cl.spnRealm(princ)
+
+	// if we don't know the SPN's realm, ask the client realm's KDC
+	if realm == "" {
+		realm = cl.Credentials.Realm()
+	}
+
+	tgt, skey, err := cl.sessionTGT(realm)
+	if err != nil {
+		return tkt, skey, err
+	}
+
+	tgsReq, err := messages.NewS4U2ProxyTGSReq(cl.Credentials.CName(), realm, cl.Config, tgt, skey, princ, false, userTicket)
+	if err != nil {
+		return tkt, skey, krberror.Errorf(err, krberror.KRBMsgError, "TGS Exchange Error: failed to generate a new S4U2Proxy TGS_REQ")
+	}
+	// do not cache proxy tickets.
+	_, tgsRep, err := cl.TGSExchangeNoCache(tgsReq, realm, tgt, skey, 0)
+	if err != nil {
+		return tkt, skey, err
+	}
+	if !tgsRep.CName.Equal(userTicket.DecryptedEncPart.CName) {
+		return tkt, skey,
+			krberror.New(krberror.KRBMsgError, fmt.Sprintf("Proxy TGS Exchange Error: expected CNAME: %s, got: %s",
+				userTicket.DecryptedEncPart.CName.PrincipalNameString(), tgsRep.CName.PrincipalNameString()))
 	}
 	return tgsRep.Ticket, tgsRep.DecryptedEncPart.Key, nil
 }

--- a/v8/client/client.go
+++ b/v8/client/client.go
@@ -300,7 +300,7 @@ func (cl *Client) Diagnostics(w io.Writer) error {
 		fmt.Fprintf(w, "TCP KDCs: %s\n", string(b))
 	}
 
-	if errs == nil || len(errs) < 1 {
+	if len(errs) < 1 {
 		return nil
 	}
 	err = fmt.Errorf(strings.Join(errs, "\n"))

--- a/v8/client/client_ad_integration_test.go
+++ b/v8/client/client_ad_integration_test.go
@@ -23,7 +23,7 @@ func TestClient_SuccessfulLogin_AD(t *testing.T) {
 	kt := keytab.New()
 	kt.Unmarshal(b)
 	c, _ := config.NewFromString(testdata.KRB5_CONF_AD)
-	cl := NewWithKeytab("testuser1", "USER.GOKRB5", kt, c, DisablePAFXFAST(true))
+	cl := NewWithKeytab("testuser1", "USER.GOKRB5", kt, c)
 
 	err := cl.Login()
 	if err != nil {
@@ -38,7 +38,7 @@ func TestClient_SuccessfulLogin_AD_Without_PreAuth(t *testing.T) {
 	kt := keytab.New()
 	kt.Unmarshal(b)
 	c, _ := config.NewFromString(testdata.KRB5_CONF_AD)
-	cl := NewWithKeytab("testuser3", "USER.GOKRB5", kt, c, DisablePAFXFAST(true))
+	cl := NewWithKeytab("testuser3", "USER.GOKRB5", kt, c)
 
 	err := cl.Login()
 	if err != nil {
@@ -98,7 +98,7 @@ func TestClient_GetServiceTicket_AD_TRUST_USER_DOMAIN(t *testing.T) {
 	c.LibDefaults.DefaultTktEnctypeIDs = []int32{etypeID.ETypesByName["rc4-hmac"]}
 	c.LibDefaults.DefaultTGSEnctypes = []string{"rc4-hmac"}
 	c.LibDefaults.DefaultTGSEnctypeIDs = []int32{etypeID.ETypesByName["rc4-hmac"]}
-	cl := NewWithKeytab("testuser1", "USER.GOKRB5", kt, c, DisablePAFXFAST(true))
+	cl := NewWithKeytab("testuser1", "USER.GOKRB5", kt, c)
 	err := cl.Login()
 
 	if err != nil {
@@ -144,7 +144,7 @@ func TestClient_GetServiceTicket_AD_USER_DOMAIN(t *testing.T) {
 	c.LibDefaults.DefaultTktEnctypeIDs = []int32{etypeID.ETypesByName["rc4-hmac"]}
 	c.LibDefaults.DefaultTGSEnctypes = []string{"rc4-hmac"}
 	c.LibDefaults.DefaultTGSEnctypeIDs = []int32{etypeID.ETypesByName["rc4-hmac"]}
-	cl := NewWithKeytab("testuser1", "USER.GOKRB5", kt, c, DisablePAFXFAST(true))
+	cl := NewWithKeytab("testuser1", "USER.GOKRB5", kt, c)
 
 	err := cl.Login()
 

--- a/v8/client/client_test.go
+++ b/v8/client/client_test.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/jcmturner/gokrb5/v8/config"
 	"github.com/jcmturner/gokrb5/v8/keytab"
+	"github.com/jcmturner/gokrb5/v8/krberror"
 )
 
 func TestAssumePreauthentication(t *testing.T) {
@@ -16,5 +17,56 @@ func TestAssumePreauthentication(t *testing.T) {
 	}
 	if !cl.settings.AssumePreAuthentication() {
 		t.Fatal("AssumePreAuthentication() should be true")
+	}
+}
+
+func TestAutoPAFXFASTDefaultsEnabled(t *testing.T) {
+	t.Parallel()
+
+	cl := NewWithKeytab("username", "REALM", &keytab.Keytab{}, &config.Config{})
+	if !cl.settings.AutoPAFXFAST() {
+		t.Fatal("AutoPAFXFAST() should default to true")
+	}
+}
+
+func TestASExchangeInitialPAFXFASTDecision(t *testing.T) {
+	t.Parallel()
+
+	cl := NewWithKeytab(
+		"username",
+		"REALM",
+		&keytab.Keytab{},
+		&config.Config{},
+		AutoPAFXFAST(false),
+		DisablePAFXFAST(true),
+	)
+	if cl.usePAFXFASTOnInitialASExchangeAttempt() {
+		t.Fatal("PA_FX_FAST should not be used when auto mode is disabled and DisablePAFXFAST is true")
+	}
+
+	cl = NewWithKeytab(
+		"username",
+		"REALM",
+		&keytab.Keytab{},
+		&config.Config{},
+		AutoPAFXFAST(true),
+		DisablePAFXFAST(true),
+	)
+	if !cl.usePAFXFASTOnInitialASExchangeAttempt() {
+		t.Fatal("PA_FX_FAST should be used on initial attempt when auto mode is enabled")
+	}
+}
+
+func TestIsPAFXFASTUnsupportedError(t *testing.T) {
+	t.Parallel()
+
+	unsupported := krberror.NewErrorf(krberror.PAFXFASTUnsupportedError, "KDC did not respond appropriately to FAST negotiation")
+	if !isPAFXFASTUnsupportedError(unsupported) {
+		t.Fatal("error should be classified as PA_FX_FAST unsupported")
+	}
+
+	nonFAST := krberror.NewErrorf(krberror.KRBMsgError, "some other AS_REP verification failure")
+	if isPAFXFASTUnsupportedError(nonFAST) {
+		t.Fatal("error should not be classified as PA_FX_FAST unsupported")
 	}
 }

--- a/v8/client/network.go
+++ b/v8/client/network.go
@@ -168,7 +168,7 @@ func sendTCP(conn *net.TCPConn, b []byte) ([]byte, error) {
 	defer conn.Close()
 	var r []byte
 	// RFC 4120 7.2.2 specifies the first 4 bytes indicate the length of the message in big endian order.
-	hb := make([]byte, 4, 4)
+	hb := make([]byte, 4)
 	binary.BigEndian.PutUint32(hb, uint32(len(b)))
 	b = append(hb, b...)
 
@@ -177,14 +177,14 @@ func sendTCP(conn *net.TCPConn, b []byte) ([]byte, error) {
 		return r, fmt.Errorf("error sending to KDC (%s): %v", conn.RemoteAddr().String(), err)
 	}
 
-	sh := make([]byte, 4, 4)
+	sh := make([]byte, 4)
 	_, err = conn.Read(sh)
 	if err != nil {
 		return r, fmt.Errorf("error reading response size header: %v", err)
 	}
 	s := binary.BigEndian.Uint32(sh)
 
-	rb := make([]byte, s, s)
+	rb := make([]byte, s)
 	_, err = io.ReadFull(conn, rb)
 	if err != nil {
 		return r, fmt.Errorf("error reading response: %v", err)

--- a/v8/client/settings.go
+++ b/v8/client/settings.go
@@ -8,6 +8,7 @@ import (
 
 // Settings holds optional client settings.
 type Settings struct {
+	autoPAFXFast            bool
 	disablePAFXFast         bool
 	assumePreAuthentication bool
 	preAuthEType            int32
@@ -16,17 +17,34 @@ type Settings struct {
 
 // jsonSettings is used when marshaling the Settings details to JSON format.
 type jsonSettings struct {
+	AutoPAFXFast            bool
 	DisablePAFXFast         bool
 	AssumePreAuthentication bool
 }
 
 // NewSettings creates a new client settings struct.
 func NewSettings(settings ...func(*Settings)) *Settings {
-	s := new(Settings)
+	s := &Settings{
+		autoPAFXFast: true,
+	}
 	for _, set := range settings {
 		set(s)
 	}
 	return s
+}
+
+// AutoPAFXFAST used to configure the client to automatically try PA_FX_FAST and retry without it.
+//
+// s := NewSettings(AutoPAFXFAST(true))
+func AutoPAFXFAST(b bool) func(*Settings) {
+	return func(s *Settings) {
+		s.autoPAFXFast = b
+	}
+}
+
+// AutoPAFXFAST indicates if the client should automatically try PA_FX_FAST and fallback without it.
+func (s *Settings) AutoPAFXFAST() bool {
+	return s.autoPAFXFast
 }
 
 // DisablePAFXFAST used to configure the client to not use PA_FX_FAST.
@@ -81,6 +99,7 @@ func (cl *Client) Log(format string, v ...interface{}) {
 // JSON returns a JSON representation of the settings.
 func (s *Settings) JSON() (string, error) {
 	js := jsonSettings{
+		AutoPAFXFast:            s.autoPAFXFast,
 		DisablePAFXFast:         s.disablePAFXFast,
 		AssumePreAuthentication: s.assumePreAuthentication,
 	}

--- a/v8/examples/example-AD.go
+++ b/v8/examples/example-AD.go
@@ -34,14 +34,14 @@ func main() {
 	kt := keytab.New()
 	kt.Unmarshal(b)
 	c, _ := config.NewFromString(testdata.KRB5_CONF)
-	cl := client.NewWithKeytab("testuser1", "USER.GOKRB5", kt, c, client.DisablePAFXFAST(true), client.Logger(l))
+	cl := client.NewWithKeytab("testuser1", "USER.GOKRB5", kt, c, client.Logger(l))
 	httpRequest(s.URL, cl)
 
 	b, _ = hex.DecodeString(testdata.KEYTAB_TESTUSER2_USER_GOKRB5)
 	kt = keytab.New()
 	kt.Unmarshal(b)
 	c, _ = config.NewFromString(testdata.KRB5_CONF)
-	cl = client.NewWithKeytab("testuser2", "USER.GOKRB5", kt, c, client.DisablePAFXFAST(true), client.Logger(l))
+	cl = client.NewWithKeytab("testuser2", "USER.GOKRB5", kt, c, client.Logger(l))
 	httpRequest(s.URL, cl)
 }
 

--- a/v8/examples/httpClient.go
+++ b/v8/examples/httpClient.go
@@ -65,7 +65,7 @@ func main() {
 	}
 
 	// Create the client with the keytab
-	cl := client.NewWithKeytab("testuser2", "TEST.GOKRB5", kt, conf, client.Logger(l), client.DisablePAFXFAST(true))
+	cl := client.NewWithKeytab("testuser2", "TEST.GOKRB5", kt, conf, client.Logger(l))
 
 	// Log in the client
 	err = cl.Login()

--- a/v8/examples/longRunningClient.go
+++ b/v8/examples/longRunningClient.go
@@ -61,7 +61,7 @@ func main() {
 	}
 
 	// Create the client with the keytab
-	cl := client.NewWithKeytab("testuser2", "TEST.GOKRB5", kt, conf, client.Logger(l), client.DisablePAFXFAST(true))
+	cl := client.NewWithKeytab("testuser2", "TEST.GOKRB5", kt, conf, client.Logger(l))
 
 	// Log in the client
 	err = cl.Login()

--- a/v8/go.mod
+++ b/v8/go.mod
@@ -1,4 +1,6 @@
-module github.com/jcmturner/gokrb5/v8
+module github.com/yoursnerdly/gokrb5/v8
+
+replace github.com/jcmturner/gokrb5/v8 => .
 
 go 1.16
 
@@ -9,8 +11,8 @@ require (
 	github.com/jcmturner/dnsutils/v2 v2.0.0
 	github.com/jcmturner/gofork v1.7.6
 	github.com/jcmturner/goidentity/v6 v6.0.1
+	github.com/jcmturner/gokrb5/v8 v8.4.4
 	github.com/jcmturner/rpc/v2 v2.0.3
 	github.com/stretchr/testify v1.8.1
 	golang.org/x/crypto v0.6.0
-	golang.org/x/net v0.7.0 // indirect
 )

--- a/v8/go.sum
+++ b/v8/go.sum
@@ -38,9 +38,8 @@ golang.org/x/net v0.0.0-20190620200207-3b0461eec859/go.mod h1:z5CRVTTTmAJ677TzLL
 golang.org/x/net v0.0.0-20200114155413-6afb5195e5aa/go.mod h1:z5CRVTTTmAJ677TzLLGU+0bjPO0LkuOLi4/5GtJWs/s=
 golang.org/x/net v0.0.0-20210226172049-e18ecbb05110/go.mod h1:m0MpNAwzfU5UDzcl9v0D8zg8gWTRqZa9RBIspLL5mdg=
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
+golang.org/x/net v0.6.0 h1:L4ZwwTvKW9gr0ZMS1yrHD9GZhIuVjOBBnaKH+SPQK0Q=
 golang.org/x/net v0.6.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
-golang.org/x/net v0.7.0 h1:rJrUqqhjsgNp7KqAIc25s9pZnjU7TUcSY7HcVZjdn1g=
-golang.org/x/net v0.7.0/go.mod h1:2Tu9+aMcznHK/AK1HMvgo6xiTLG5rD5rZLDS+rp2Bjs=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/v8/iana/flags/constants.go
+++ b/v8/iana/flags/constants.go
@@ -20,6 +20,7 @@ const (
 	RequestAnonymous       = 12
 	TransitedPolicyChecked = 12
 	OKAsDelegate           = 13
+	CnameInAddlTkt         = 14 // Microsoft extension (MS-SFU)
 	EncPARep               = 15
 	Canonicalize           = 15
 	DisableTransitedCheck  = 26

--- a/v8/iana/patype/constants.go
+++ b/v8/iana/patype/constants.go
@@ -74,4 +74,13 @@ const (
 	//UNASSIGNED : 151-164
 	PA_SUPPORTED_ETYPES int32 = 165
 	PA_EXTENDED_ERROR   int32 = 166
+	PA_PAC_OPTIONS      int32 = 167 // Microsoft extension (MS-KILE)
+)
+
+// Microsoft extension - MS-KILE, MS-SFU
+const (
+	PA_PAC_OPTION_CLAIMS                                int = 0
+	PA_PAC_OPTION_BRANCH_AWARE                          int = 1
+	PA_PAC_OPTION_FORWARD_TO_FULL_DC                    int = 2
+	PA_PAC_OPTION_RESOURCE_BASED_CONSTRAINED_DELEGATION int = 3
 )

--- a/v8/keytab/keytab.go
+++ b/v8/keytab/keytab.go
@@ -156,6 +156,35 @@ func (kt *Keytab) AddEntry(principalName, realm, password string, ts time.Time, 
 	return nil
 }
 
+// AddEntryWithKey adds an entry to the keytab with the given key. This is needed when the key is associated
+// with a user that may be associated with multiple SPNs. The same key is then needed for each of those
+// SPNs.
+func (kt *Keytab) AddEntryWithKey(principalName, realm string, key types.EncryptionKey, ts time.Time, KVNO uint8) {
+	// Generate a key from the password
+	princ, _ := types.ParseSPNString(principalName)
+
+	// Populate the keytab entry principal
+	ktep := newPrincipal()
+	ktep.NumComponents = int16(len(princ.NameString))
+	if kt.version == 1 {
+		ktep.NumComponents += 1
+	}
+
+	ktep.Realm = realm
+	ktep.Components = princ.NameString
+	ktep.NameType = princ.NameType
+
+	// Populate the keytab entry
+	e := newEntry()
+	e.Principal = ktep
+	e.Timestamp = ts
+	e.KVNO8 = KVNO
+	e.KVNO = uint32(KVNO)
+	e.Key = key
+
+	kt.Entries = append(kt.Entries, e)
+}
+
 // Create a new principal.
 func newPrincipal() principal {
 	var c []string

--- a/v8/krberror/error.go
+++ b/v8/krberror/error.go
@@ -8,15 +8,16 @@ import (
 
 // Error type descriptions.
 const (
-	separator       = " < "
-	EncodingError   = "Encoding_Error"
-	NetworkingError = "Networking_Error"
-	DecryptingError = "Decrypting_Error"
-	EncryptingError = "Encrypting_Error"
-	ChksumError     = "Checksum_Error"
-	KRBMsgError     = "KRBMessage_Handling_Error"
-	ConfigError     = "Configuration_Error"
-	KDCError        = "KDC_Error"
+	separator                = " < "
+	EncodingError            = "Encoding_Error"
+	NetworkingError          = "Networking_Error"
+	DecryptingError          = "Decrypting_Error"
+	EncryptingError          = "Encrypting_Error"
+	ChksumError              = "Checksum_Error"
+	KRBMsgError              = "KRBMessage_Handling_Error"
+	PAFXFASTUnsupportedError = "PAFXFAST_Unsupported_Error"
+	ConfigError              = "Configuration_Error"
+	KDCError                 = "KDC_Error"
 )
 
 // Krberror is an error type for gokrb5

--- a/v8/messages/APRep.go
+++ b/v8/messages/APRep.go
@@ -1,11 +1,17 @@
 package messages
 
 import (
+	"crypto/rand"
 	"fmt"
+	"math"
+	"math/big"
 	"time"
 
 	"github.com/jcmturner/gofork/encoding/asn1"
+	"github.com/jcmturner/gokrb5/v8/asn1tools"
+	"github.com/jcmturner/gokrb5/v8/crypto"
 	"github.com/jcmturner/gokrb5/v8/iana/asnAppTag"
+	"github.com/jcmturner/gokrb5/v8/iana/keyusage"
 	"github.com/jcmturner/gokrb5/v8/iana/msgtype"
 	"github.com/jcmturner/gokrb5/v8/krberror"
 	"github.com/jcmturner/gokrb5/v8/types"
@@ -24,6 +30,39 @@ type EncAPRepPart struct {
 	Cusec          int                 `asn1:"explicit,tag:1"`
 	Subkey         types.EncryptionKey `asn1:"optional,explicit,tag:2"`
 	SequenceNumber int64               `asn1:"optional,explicit,tag:3"`
+}
+
+// NewAPRep prepares and returns a new APRep message in response to a validated APReq.
+func NewAPRep(req APReq) (APRep, error) {
+	var a APRep
+	seq, err := rand.Int(rand.Reader, big.NewInt(math.MaxUint32))
+	if err != nil {
+		return a, err
+	}
+	usage := uint32(keyusage.AP_REP_ENCPART)
+	key := req.Ticket.DecryptedEncPart.Key
+	encAPRepPart := EncAPRepPart{
+		CTime:          req.Authenticator.CTime.UTC(),
+		Cusec:          req.Authenticator.Cusec,
+		SequenceNumber: seq.Int64() & 0x3fffffff,
+		Subkey:         req.Authenticator.SubKey, // confirm request subkey if any.
+	}
+	fmt.Printf("Creating EncAPRepPart: %#v\n", encAPRepPart)
+	b, err := encAPRepPart.Marshal()
+	if err != nil {
+		return a, err
+	}
+	ed, err := crypto.GetEncryptedData(b, key, usage, 0)
+	if err != nil {
+		return a, err
+	}
+
+	a = APRep{
+		PVNO:    5,
+		MsgType: msgtype.KRB_AP_REP,
+		EncPart: ed,
+	}
+	return a, nil
 }
 
 // Unmarshal bytes b into the APRep struct.
@@ -46,4 +85,24 @@ func (a *EncAPRepPart) Unmarshal(b []byte) error {
 		return krberror.Errorf(err, krberror.EncodingError, "AP_REP unmarshal error")
 	}
 	return nil
+}
+
+// Marshal the EncAPRepPart.
+func (a *EncAPRepPart) Marshal() ([]byte, error) {
+	b, err := asn1.Marshal(*a)
+	if err != nil {
+		return nil, krberror.Errorf(err, krberror.EncodingError, "AP_REP marshal error")
+	}
+	b = asn1tools.AddASNAppTag(b, asnAppTag.EncAPRepPart)
+	return b, nil
+}
+
+// Marshal APRep struct.
+func (a *APRep) Marshal() ([]byte, error) {
+	mk, err := asn1.Marshal(*a)
+	if err != nil {
+		return mk, krberror.Errorf(err, krberror.EncodingError, "marshaling error of AP_REP")
+	}
+	mk = asn1tools.AddASNAppTag(mk, asnAppTag.APREP)
+	return mk, nil
 }

--- a/v8/messages/KDCRep.go
+++ b/v8/messages/KDCRep.go
@@ -246,13 +246,6 @@ func (k *ASRep) DecryptEncPart(c *credentials.Credentials) (types.EncryptionKey,
 
 // Verify checks the validity of AS_REP message.
 func (k *ASRep) Verify(cfg *config.Config, creds *credentials.Credentials, asReq ASReq) (bool, error) {
-	//Ref RFC 4120 Section 3.1.5
-	if !k.CName.Equal(asReq.ReqBody.CName) {
-		return false, krberror.NewErrorf(krberror.KRBMsgError, "CName in response does not match what was requested. Requested: %+v; Reply: %+v", asReq.ReqBody.CName, k.CName)
-	}
-	if k.CRealm != asReq.ReqBody.Realm {
-		return false, krberror.NewErrorf(krberror.KRBMsgError, "CRealm in response does not match what was requested. Requested: %s; Reply: %s", asReq.ReqBody.Realm, k.CRealm)
-	}
 	key, err := k.DecryptEncPart(creds)
 	if err != nil {
 		return false, krberror.Errorf(err, krberror.DecryptingError, "error decrypting EncPart of AS_REP")
@@ -318,12 +311,13 @@ func (k *TGSRep) DecryptEncPart(key types.EncryptionKey) error {
 
 // Verify checks the validity of the TGS_REP message.
 func (k *TGSRep) Verify(cfg *config.Config, tgsReq TGSReq) (bool, error) {
-	if !k.CName.Equal(tgsReq.ReqBody.CName) {
-		return false, krberror.NewErrorf(krberror.KRBMsgError, "CName in response does not match what was requested. Requested: %+v; Reply: %+v", tgsReq.ReqBody.CName, k.CName)
-	}
-	if k.Ticket.Realm != tgsReq.ReqBody.Realm {
-		return false, krberror.NewErrorf(krberror.KRBMsgError, "realm in response ticket does not match what was requested. Requested: %s; Reply: %s", tgsReq.ReqBody.Realm, k.Ticket.Realm)
-	}
+	// CName and realm may not match in case of S4U2Self or S4U2Proxy requests.
+	// if !k.CName.Equal(tgsReq.ReqBody.CName) {
+	// 	return false, krberror.NewErrorf(krberror.KRBMsgError, "CName in response does not match what was requested. Requested: %+v; Reply: %+v", tgsReq.ReqBody.CName, k.CName)
+	// }
+	// if k.Ticket.Realm != tgsReq.ReqBody.Realm {
+	// 	return false, krberror.NewErrorf(krberror.KRBMsgError, "realm in response ticket does not match what was requested. Requested: %s; Reply: %s", tgsReq.ReqBody.Realm, k.Ticket.Realm)
+	// }
 	if k.DecryptedEncPart.Nonce != tgsReq.ReqBody.Nonce {
 		return false, krberror.NewErrorf(krberror.KRBMsgError, "possible replay attack, nonce in response does not match that in request")
 	}

--- a/v8/messages/KDCRep.go
+++ b/v8/messages/KDCRep.go
@@ -271,7 +271,7 @@ func (k *ASRep) Verify(cfg *config.Config, creds *credentials.Credentials, asReq
 	// RFC 6806 https://tools.ietf.org/html/rfc6806.html#section-11
 	if asReq.PAData.Contains(patype.PA_REQ_ENC_PA_REP) && types.IsFlagSet(&k.DecryptedEncPart.Flags, flags.EncPARep) {
 		if len(k.DecryptedEncPart.EncPAData) < 2 || !k.DecryptedEncPart.EncPAData.Contains(patype.PA_FX_FAST) {
-			return false, krberror.NewErrorf(krberror.KRBMsgError, "KDC did not respond appropriately to FAST negotiation")
+			return false, krberror.NewErrorf(krberror.PAFXFASTUnsupportedError, "KDC did not respond appropriately to FAST negotiation")
 		}
 		for _, pa := range k.DecryptedEncPart.EncPAData {
 			if pa.PADataType == patype.PA_REQ_ENC_PA_REP {

--- a/v8/messages/KDCReq.go
+++ b/v8/messages/KDCReq.go
@@ -175,6 +175,31 @@ func NewUser2UserTGSReq(cname types.PrincipalName, kdcRealm string, c *config.Co
 	return a, err
 }
 
+// NewS4U2ProxyTGSReq returns a TGS-REQ suitable for obtaining a proxy ticket on behalf of some user.
+// userTicket must be a forwardable ticket for the user.
+func NewS4U2ProxyTGSReq(cname types.PrincipalName, kdcRealm string, c *config.Config, clientTGT Ticket, sessionKey types.EncryptionKey, sname types.PrincipalName, renewal bool, userTicket Ticket) (TGSReq, error) {
+	a, err := tgsReq(cname, sname, kdcRealm, renewal, c)
+	if err != nil {
+		return a, err
+	}
+	a.ReqBody.AdditionalTickets = []Ticket{
+		// ensure we don't include the decrypted enc part in the marshaled ticket.
+		{
+			TktVNO:  userTicket.TktVNO,
+			Realm:   userTicket.Realm,
+			SName:   userTicket.SName,
+			EncPart: userTicket.EncPart,
+		},
+	}
+	types.SetFlag(&a.ReqBody.KDCOptions, flags.CnameInAddlTkt)
+	err = a.setPAData(clientTGT, sessionKey)
+	if err != nil {
+		return a, err
+	}
+	err = a.setPAPACOptions(patype.PA_PAC_OPTION_RESOURCE_BASED_CONSTRAINED_DELEGATION)
+	return a, err
+}
+
 // tgsReq populates the fields for a TGS_REQ
 func tgsReq(cname, sname types.PrincipalName, kdcRealm string, renewal bool, c *config.Config) (TGSReq, error) {
 	nonce, err := rand.Int(rand.Reader, big.NewInt(math.MaxInt32))
@@ -266,6 +291,26 @@ func (k *TGSReq) setPAData(tgt Ticket, sessionKey types.EncryptionKey) error {
 			PADataValue: apb,
 		},
 	}
+	return nil
+}
+
+func (k *TGSReq) setPAPACOptions(bits ...int) error {
+	papacOptions := types.PAPACOptions{
+		Flags: types.NewKrbFlags(),
+	}
+	for _, b := range bits {
+		types.SetFlag(&(papacOptions.Flags), b)
+	}
+	opts, err := asn1.Marshal(papacOptions)
+	if err != nil {
+		return krberror.Errorf(err, krberror.EncodingError, "error marshaling PAC options for TGS request")
+	}
+	k.PAData = append(k.PAData,
+		types.PAData{
+			PADataType:  patype.PA_PAC_OPTIONS,
+			PADataValue: opts,
+		},
+	)
 	return nil
 }
 

--- a/v8/spnego/http.go
+++ b/v8/spnego/http.go
@@ -232,8 +232,6 @@ const (
 	spnegoNegTokenRespIncompleteKRB5 = "Negotiate oRQwEqADCgEBoQsGCSqGSIb3EgECAg=="
 	// sessionCredentials is the session value key holding the credentials jcmturner/goidentity/Identity object.
 	sessionCredentials = "github.com/jcmturner/gokrb5/v8/sessionCredentials"
-	// ctxCredentials is the SPNEGO context key holding the credentials jcmturner/goidentity/Identity object.
-	ctxCredentials = "github.com/jcmturner/gokrb5/v8/ctxCredentials"
 	// HTTPHeaderAuthRequest is the header that will hold authn/z information.
 	HTTPHeaderAuthRequest = "Authorization"
 	// HTTPHeaderAuthResponse is the header that will hold SPNEGO data from the server.
@@ -243,6 +241,12 @@ const (
 	// UnauthorizedMsg is the message returned in the body when authentication fails.
 	UnauthorizedMsg = "Unauthorised.\n"
 )
+
+// CtxCredentialsKey is the SPNEGO context key holding the credentials jcmturner/goidentity/Identity object.
+type CtxCredentialsKey struct{}
+
+// CtxAPReqKey is the SPNEGO context key holding the incoming AP-REQ if any.
+type CtxAPReqKey struct{}
 
 // SPNEGOKRB5Authenticate is a Kerberos SPNEGO authentication HTTP handler wrapper.
 func SPNEGOKRB5Authenticate(inner http.Handler, kt *keytab.Keytab, settings ...func(*service.Settings)) http.Handler {
@@ -287,7 +291,7 @@ func SPNEGOKRB5Authenticate(inner http.Handler, kt *keytab.Keytab, settings ...f
 
 		if authed {
 			// Authentication successful; get user's credentials from the context
-			id := ctx.Value(ctxCredentials).(*credentials.Credentials)
+			id := ctx.Value(CtxCredentialsKey{}).(*credentials.Credentials)
 			// Create a new session if a session manager has been configured
 			err = newSession(spnego, r, w, id)
 			if err != nil {

--- a/v8/spnego/krb5Token.go
+++ b/v8/spnego/krb5Token.go
@@ -10,7 +10,6 @@ import (
 	"github.com/jcmturner/gofork/encoding/asn1"
 	"github.com/jcmturner/gokrb5/v8/asn1tools"
 	"github.com/jcmturner/gokrb5/v8/client"
-	"github.com/jcmturner/gokrb5/v8/credentials"
 	"github.com/jcmturner/gokrb5/v8/gssapi"
 	"github.com/jcmturner/gokrb5/v8/iana/chksumtype"
 	"github.com/jcmturner/gokrb5/v8/iana/msgtype"
@@ -52,7 +51,10 @@ func (m *KRB5Token) Marshal() ([]byte, error) {
 			return []byte{}, fmt.Errorf("error marshalling AP_REQ for MechToken: %v", err)
 		}
 	case TOK_ID_KRB_AP_REP:
-		return []byte{}, errors.New("marshal of AP_REP GSSAPI MechToken not supported by gokrb5")
+		tb, err = m.APRep.Marshal()
+		if err != nil {
+			return []byte{}, fmt.Errorf("error marshalling AP_REP for MechToken: %v", err)
+		}
 	case TOK_ID_KRB_ERROR:
 		return []byte{}, errors.New("marshal of KRB_ERROR GSSAPI MechToken not supported by gokrb5")
 	}
@@ -116,7 +118,8 @@ func (m *KRB5Token) Verify() (bool, gssapi.Status) {
 			return false, gssapi.Status{Code: gssapi.StatusDefectiveCredential, Message: "KRB5_AP_REQ token not valid"}
 		}
 		m.context = context.Background()
-		m.context = context.WithValue(m.context, ctxCredentials, creds)
+		m.context = context.WithValue(m.context, CtxCredentialsKey{}, creds)
+		m.context = context.WithValue(m.context, CtxAPReqKey{}, m.APReq)
 		return true, gssapi.Status{Code: gssapi.StatusComplete}
 	case TOK_ID_KRB_AP_REP:
 		// Client side
@@ -163,12 +166,27 @@ func (m *KRB5Token) Context() context.Context {
 // NewKRB5TokenAPREQ creates a new KRB5 token with AP_REQ
 func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.EncryptionKey, GSSAPIFlags []int, APOptions []int) (KRB5Token, error) {
 	// TODO consider providing the SPN rather than the specific tkt and key and get these from the krb client.
+	return NewKRB5TokenProxyAPREQ(tkt, sessionKey, cl.Credentials.Domain(), cl.Credentials.CName(), GSSAPIFlags, APOptions)
+}
+
+// NewKRB5TokenAPREP creates a new KRB5 token with AP_REP
+func NewKRB5TokenAPREP(aprep messages.APRep) (KRB5Token, error) {
+	var m KRB5Token
+	m.OID = gssapi.OIDKRB5.OID()
+	tb, _ := hex.DecodeString(TOK_ID_KRB_AP_REP)
+	m.tokID = tb
+	m.APRep = aprep
+	return m, nil
+}
+
+// NewKRB5TokenProxyAPREQ creates a new KRB5 token with AP_REQ for a proxy ticket.
+func NewKRB5TokenProxyAPREQ(tkt messages.Ticket, sessionKey types.EncryptionKey, realm string, cname types.PrincipalName, GSSAPIFlags []int, APOptions []int) (KRB5Token, error) {
 	var m KRB5Token
 	m.OID = gssapi.OIDKRB5.OID()
 	tb, _ := hex.DecodeString(TOK_ID_KRB_AP_REQ)
 	m.tokID = tb
 
-	auth, err := krb5TokenAuthenticator(cl.Credentials, GSSAPIFlags)
+	auth, err := krb5TokenAuthenticator(realm, cname, GSSAPIFlags)
 	if err != nil {
 		return m, err
 	}
@@ -188,9 +206,9 @@ func NewKRB5TokenAPREQ(cl *client.Client, tkt messages.Ticket, sessionKey types.
 }
 
 // krb5TokenAuthenticator creates a new kerberos authenticator for kerberos MechToken
-func krb5TokenAuthenticator(creds *credentials.Credentials, flags []int) (types.Authenticator, error) {
+func krb5TokenAuthenticator(realm string, cname types.PrincipalName, flags []int) (types.Authenticator, error) {
 	//RFC 4121 Section 4.1.1
-	auth, err := types.NewAuthenticator(creds.Domain(), creds.CName())
+	auth, err := types.NewAuthenticator(realm, cname)
 	if err != nil {
 		return auth, krberror.Errorf(err, krberror.KRBMsgError, "error generating new authenticator")
 	}

--- a/v8/spnego/krb5Token_test.go
+++ b/v8/spnego/krb5Token_test.go
@@ -57,7 +57,7 @@ func TestKRB5Token_newAuthenticatorWithSubkeyGeneration(t *testing.T) {
 	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
 	var etypeID int32 = 18
 	keyLen := 32 // etypeID 18 refers to AES256 -> 32 bytes key
-	a, err := krb5TokenAuthenticator(creds, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
+	a, err := krb5TokenAuthenticator(creds.Realm(), creds.CName(), []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
 	if err != nil {
 		t.Fatalf("Error creating authenticator: %v", err)
 	}
@@ -85,7 +85,7 @@ func TestKRB5Token_newAuthenticator(t *testing.T) {
 	t.Parallel()
 	creds := credentials.New("hftsai", testdata.TEST_REALM)
 	creds.SetCName(types.PrincipalName{NameType: nametype.KRB_NT_PRINCIPAL, NameString: testdata.TEST_PRINCIPALNAME_NAMESTRING})
-	a, err := krb5TokenAuthenticator(creds, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
+	a, err := krb5TokenAuthenticator(creds.Realm(), creds.CName(), []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf})
 	if err != nil {
 		t.Fatalf("Error creating authenticator: %v", err)
 	}

--- a/v8/spnego/negotiationToken.go
+++ b/v8/spnego/negotiationToken.go
@@ -300,3 +300,58 @@ func NewNegTokenInitKRB5(cl *client.Client, tkt messages.Ticket, sessionKey type
 		MechTokenBytes: mtb,
 	}, nil
 }
+
+// NewNegTokenRespKRB5 creates a new Resp negotiation token for Kerberos 5
+// from an incoming SPNego init token and validated APReq message.
+func NewNegTokenRespKRB5(ct gssapi.ContextToken, apReq messages.APReq) (NegTokenResp, error) {
+	var n NegTokenResp
+
+	t, ok := ct.(*SPNEGOToken)
+	if !ok {
+		return n, errors.New("context token provided was not an SPNEGO token")
+	}
+	if !t.Init {
+		return n, errors.New("SPNEGO token provided was not a NegTokenInit")
+	}
+	var oid asn1.ObjectIdentifier
+	if t.Init {
+		oid = t.NegTokenInit.MechTypes[0]
+	}
+
+	aprep, err := messages.NewAPRep(apReq)
+	if err != nil {
+		return n, fmt.Errorf("failed to create APRep: %w", err)
+	}
+	mt, err := NewKRB5TokenAPREP(aprep)
+	if err != nil {
+		return n, fmt.Errorf("failed to create KRB5 token APREP: %w", err)
+	}
+	mtb, err := mt.Marshal()
+	if err != nil {
+		return n, fmt.Errorf("failed to marshal KRB5 token APREP: %w", err)
+	}
+	n = NegTokenResp{
+		NegState:      asn1.Enumerated(NegStateAcceptCompleted),
+		ResponseToken: mtb,
+		SupportedMech: oid,
+	}
+	return n, nil
+}
+
+// NewNegTokenInitKRB5 creates new Init negotiation token for Kerberos 5 using a proxy ticket
+func NewNegTokenInitProxyKRB5(
+	tkt messages.Ticket, sessionKey types.EncryptionKey, realm string, cname types.PrincipalName, APOptions []int,
+) (NegTokenInit, error) {
+	mt, err := NewKRB5TokenProxyAPREQ(tkt, sessionKey, realm, cname, []int{gssapi.ContextFlagInteg, gssapi.ContextFlagConf}, APOptions)
+	if err != nil {
+		return NegTokenInit{}, fmt.Errorf("error getting KRB5 token; %v", err)
+	}
+	mtb, err := mt.Marshal()
+	if err != nil {
+		return NegTokenInit{}, fmt.Errorf("error marshalling KRB5 token; %v", err)
+	}
+	return NegTokenInit{
+		MechTypes:      []asn1.ObjectIdentifier{gssapi.OIDKRB5.OID()},
+		MechTokenBytes: mtb,
+	}, nil
+}

--- a/v8/spnego/spnego.go
+++ b/v8/spnego/spnego.go
@@ -11,6 +11,7 @@ import (
 	"github.com/jcmturner/gokrb5/v8/client"
 	"github.com/jcmturner/gokrb5/v8/gssapi"
 	"github.com/jcmturner/gokrb5/v8/keytab"
+	"github.com/jcmturner/gokrb5/v8/messages"
 	"github.com/jcmturner/gokrb5/v8/service"
 )
 
@@ -54,6 +55,24 @@ func (s *SPNEGO) InitSecContext() (gssapi.ContextToken, error) {
 		return &SPNEGOToken{}, err
 	}
 	negTokenInit, err := NewNegTokenInitKRB5(s.client, tkt, key)
+	if err != nil {
+		return &SPNEGOToken{}, fmt.Errorf("could not create NegTokenInit: %v", err)
+	}
+	return &SPNEGOToken{
+		Init:         true,
+		NegTokenInit: negTokenInit,
+		settings:     s.serviceSettings,
+	}, nil
+}
+
+// InitProxySecContext is the GSS-API method for the client to generate a proxy token for the
+// service, using a user's verified forwardable ticket.
+func (s *SPNEGO) InitProxySecContext(userTicket messages.Ticket, opts []int) (gssapi.ContextToken, error) {
+	tkt, key, err := s.client.GetProxyTicket(s.spn, userTicket)
+	if err != nil {
+		return &SPNEGOToken{}, err
+	}
+	negTokenInit, err := NewNegTokenInitProxyKRB5(tkt, key, userTicket.DecryptedEncPart.CRealm, userTicket.DecryptedEncPart.CName, opts)
 	if err != nil {
 		return &SPNEGOToken{}, fmt.Errorf("could not create NegTokenInit: %v", err)
 	}

--- a/v8/types/PAData.go
+++ b/v8/types/PAData.go
@@ -153,3 +153,8 @@ func (pa *PAData) GetETypeInfo2() (d ETypeInfo2, err error) {
 	_, err = asn1.Unmarshal(pa.PADataValue, &d)
 	return
 }
+
+// PAPACOptions represents the PAC options in the PAData - Microsoft extension (MS-KILE).
+type PAPACOptions struct {
+	Flags asn1.BitString `asn1:"explicit,tag:0"`
+}


### PR DESCRIPTION
This PR adds an AutoPAFXFAST option to client settings (enabled by default) that causes the ASExchange to automatically retry with PAFXFAST disabled if the initial attempt with PAFXFAST result in the specific error that the server does not support PAFXFAST exchange.